### PR TITLE
Added dummy satellite program

### DIFF
--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(client)
 add_subdirectory(light-client)
+add_subdirectory(dummy-satellite)
 add_subdirectory(server)
 add_subdirectory(viewtree)

--- a/projects/README.md
+++ b/projects/README.md
@@ -5,11 +5,16 @@
 Runs the network table server
 
 ## Client
-
 An example client of the Network Table.
 This is also used to test the functionality of
 the NetworkTable.
 
 ## Viewtree
-
 Prints out all the values in the network table
+
+## Light Client
+Simply updates a single value in the network table forever
+
+## Dummy Satellite
+Synchronize two network tables
+on either end of an ethernet cable.

--- a/projects/client/main.cpp
+++ b/projects/client/main.cpp
@@ -20,7 +20,9 @@ std::atomic_bool gps_quality_callback_called(false); // It would be better to
                                                       // but this depends on what other
                                                       // clients are doing.
 std::atomic_bool wrong_gps_quality_data_received(false);
-void GpsQualityCallback(NetworkTable::Node node) {
+void GpsQualityCallback(NetworkTable::Node node, \
+        std::map<std::string, NetworkTable::Value> diffs, \
+        bool is_self_reply) {
     gps_quality_callback_called = true;
     auto data = node.value().int_data();
     if (data != 3) {
@@ -32,7 +34,9 @@ void GpsQualityCallback(NetworkTable::Node node) {
 
 std::atomic_bool root_callback_called(false);
 std::atomic_bool wrong_root_data_received(false);
-void RootCallback(NetworkTable::Node node) {
+void RootCallback(NetworkTable::Node node, \
+        std::map<std::string, NetworkTable::Value> diffs, \
+        bool is_self_reply) {
     root_callback_called = true;
     auto data = node.children().at("gps").children().at("gpgga")\
             .children().at("quality_indicator").value().int_data();

--- a/projects/dummy-satellite/CMakeLists.txt
+++ b/projects/dummy-satellite/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Set a variable for commands below
+set(PROJECT_NAME dummy-satellite)
+
+# Define your project and language
+project(${PROJECT_NAME} CXX)
+
+# Define the source code
+set(${PROJECT_NAME}_SRCS main.cpp)
+
+# Define the executable
+add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
+target_link_libraries(${PROJECT_NAME} ${ZMQ_LIBRARIES} ${PROTOBUF_LIBRARIES} src_core)

--- a/projects/dummy-satellite/main.cpp
+++ b/projects/dummy-satellite/main.cpp
@@ -1,0 +1,112 @@
+// Copyright 2017 UBC Sailbot
+//
+// Sends requests to the network table
+
+#include "Connection.h"
+#include "Node.pb.h"
+#include "Value.pb.h"
+#include <zmq.hpp>
+#include <map>
+#include <string>
+
+zmq::context_t context(1);
+zmq::socket_t eth_socket(context, ZMQ_PAIR);
+NetworkTable::Node cur_nt;
+
+/*
+ * Send data over the ethernet connection.
+ */
+void send(const std::string &data) {
+    zmq::message_t request(data.size()+1);
+    memcpy(request.data(), data.c_str(), data.size()+1);
+    eth_socket.send(request);
+}
+
+/*
+ * Receive data over the ethernet connection.
+ * Returns true if something was received,
+ * false otherwise
+ */
+bool receive(std::map<std::string, NetworkTable::Value> &diffs) {
+    zmq::message_t reply;
+
+    int rc = eth_socket.recv(&reply);
+
+    if (rc > 0) {
+        std::string request_serialized = static_cast<char*>(reply.data());
+        NetworkTable::SetValuesRequest request;
+        request.ParseFromString(request_serialized);
+        for (auto const &entry : request.values()) {
+            std::string uri = entry.first;
+            NetworkTable::Value value = entry.second;
+            diffs[uri] = value;
+        }
+        return true;
+    }
+    return false;
+}
+
+void RootCallback(NetworkTable::Node node, \
+        std::map<std::string, NetworkTable::Value> diffs, \
+        bool is_self_reply) {
+    if (!is_self_reply) {
+        // Use a set values request to send the info.
+        NetworkTable::SetValuesRequest request;
+        auto mutable_values = request.mutable_values();
+        for (auto const &entry : diffs) {
+            std::string uri = entry.first;
+            NetworkTable::Value value = entry.second;
+            (*mutable_values)[uri] = value;
+        }
+
+        std::string serialized_request;
+        request.SerializeToString(&serialized_request);
+
+        send(serialized_request);
+        std::cout << "send our diff" << std::endl;
+    }
+}
+
+/*
+ * Subscribe to receive any changes in the entire
+ * network table. When a change occurs, send ONLY the
+ * difference over the ethernet cable.
+ * Also receive changes from the ethernet cable,
+ * and place those changes in the local network table.
+ * This program is meant to run on the beaglebone and
+ * on the webserver.
+ */
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        std::cout << "Please provide ip address of other end"
+            " of ethernet cable. Example:\n"
+            "./dummy-satellite 10.0.0.8" << std::endl;
+        return 1;
+    }
+
+    NetworkTable::Connection connection;
+    connection.SetTimeout(1000);
+    try {
+        connection.Connect();
+    } catch (NetworkTable::TimeoutException) {
+        std::cout << "Failed to connect to server." << std::endl;
+        return 0;
+    }
+
+    try {
+        eth_socket.bind("tcp://" + std::string(argv[1]) + ":5555");
+    } catch (std::exception &e) {
+        std::cout << e.what() << std::endl;
+        return 0;
+    }
+
+    cur_nt = connection.GetNode("/");
+    connection.Subscribe("/", &RootCallback);
+    while (true) {
+        std::map<std::string, NetworkTable::Value> their_diff;
+        if (receive(their_diff)) {
+            std::cout << "received their diff" << std::endl;
+            connection.SetValues(their_diff);
+        }
+    }
+}

--- a/src/Server.h
+++ b/src/Server.h
@@ -61,7 +61,8 @@ const std::string kSubscriptionsTableFilePath_ = kWelcome_Directory_ + "subscrip
      * must send back a reply, so the helper function
      * also needs a socket to send the reply to.
      */
-    void SetValues(const NetworkTable::SetValuesRequest &request);
+    void SetValues(const NetworkTable::SetValuesRequest &request, \
+            socket_ptr socket);
 
     void GetNodes(const NetworkTable::GetNodesRequest &request, \
             std::string id, socket_ptr socket);
@@ -83,8 +84,11 @@ const std::string kSubscriptionsTableFilePath_ = kWelcome_Directory_ + "subscrip
 
     /*
      * Gets any sockets which have subscribed to key, and sends value to them.
+     * Also include who caused this notify.
      */
-    void NotifySubscribers(const std::set<std::string> &uris);
+    void NotifySubscribers(const std::set<std::string> &uris, \
+            const google::protobuf::Map<std::string, NetworkTable::Value> &diffs, \
+            socket_ptr responsible_socket);
 
     /*
      * Serializes a network table reply,

--- a/src/protofiles/SubscribeReply.proto
+++ b/src/protofiles/SubscribeReply.proto
@@ -3,8 +3,18 @@ syntax = "proto3";
 package NetworkTable;
 
 import "Node.proto";
+import "Value.proto";
 
 message SubscribeReply {
     string uri = 1;
+
+    // This node that changed. This is the node at uri.
     Node node = 2;
+    
+    // List of differences.
+    map<string, Value> diffs = 3;
+
+    // Name of the socket which caused this
+    // reply to be sent
+    string responsible_socket = 4;
 }


### PR DESCRIPTION
This program will sink two network tables connected by an ethernet
cable. Whenever a change is made to the local network table, these
changes are sent across the ethernet cable to be applied to the remote
network table.
Some of the source code had to be updated to allow the user to know if a
subscription update occured because of their own SetValues request, or
because some other process sent a SetValues request. Without this, an
infinite loop where the program would update the network table, and send
this change across the ethernet cable, and the program on the other side
would do the same.

To run this, the side that starts first has to call zmq bind, and the
side the then connects has to call zmq connect, so the code has to be
modified before running. This might be fixed in the future.