### PR TITLE
Added command line args for dummy-satellite

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -18,3 +18,16 @@ Simply updates a single value in the network table forever
 ## Dummy Satellite
 Synchronize two network tables
 on either end of an ethernet cable.
+
+One side must act as a server. When running on this side,
+find the ip address of your ethernet port (ie with 'ifconfig'),
+and run   
+'''./dummy-satellite server <ip_address>'''
+
+On the other side, you must connect to the _same_ ip address,
+but as a client. Use the following command:  
+'''./dummy-satellite client <ip_address>'''
+
+Note that the code is 99% the same on the client and server side.
+It's just the zmq has to call bind on the server side,
+and connect on the client side in order to work.

--- a/projects/dummy-satellite/main.cpp
+++ b/projects/dummy-satellite/main.cpp
@@ -67,6 +67,13 @@ void RootCallback(NetworkTable::Node node, \
     }
 }
 
+void PrintUsage() {
+    std::cout << "Provide the ip address to connect to, as well as whether"
+        "  this is client or server. Example:\n"
+        "./dummy-satellite client 10.0.0.8" << std::endl <<
+        "./dummy-satellite server 10.0.0.8" << std::endl;
+}
+
 /*
  * Subscribe to receive any changes in the entire
  * network table. When a change occurs, send ONLY the
@@ -77,10 +84,8 @@ void RootCallback(NetworkTable::Node node, \
  * on the webserver.
  */
 int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        std::cout << "Please provide ip address of other end"
-            " of ethernet cable. Example:\n"
-            "./dummy-satellite 10.0.0.8" << std::endl;
+    if (argc != 3) {
+        PrintUsage();
         return 1;
     }
 
@@ -94,7 +99,14 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        eth_socket.bind("tcp://" + std::string(argv[1]) + ":5555");
+        if (strcmp(argv[1], "server") == 0) {
+            eth_socket.bind("tcp://" + std::string(argv[1]) + ":5555");
+        } else if (strcmp(argv[1], "client") == 0) {
+            eth_socket.connect("tcp://" + std::string(argv[1]) + ":5555");
+        } else {
+            PrintUsage();
+            return 1;
+        }
     } catch (std::exception &e) {
         std::cout << e.what() << std::endl;
         return 0;


### PR DESCRIPTION
One side acts as a server, and the other a client. The code on both
sides is 99% the same, its just that zmq needs to call bind on the
server side, and connect on the client side. Command line args can now
be used to specify which side is client and which side is the server.