### PR TITLE
Nav-12 Send Sensor/UCCM Data to RockBlock

### DIFF
--- a/projects/rockblock/main.cpp
+++ b/projects/rockblock/main.cpp
@@ -5,11 +5,27 @@
 #include "Connection.h"
 #include <thread>
 #include <bitset>
+#include <string>
 #include <cstring>
 #include <iomanip>
 #include <boost/algorithm/string.hpp>
+#include "Help.h"
+#include "Sensors.pb.h"
+#include "Uccms.pb.h"
+#include <thread>
+#include <mutex>
 
-void receive_message(std::string&, std::string);
+// Stores serialized sensor and uccm data to send to rockblock
+std::string most_recent_sensorData_string;
+std::string most_recent_uccmData_string;
+
+// How often to send sensor and uccm data
+uint16_t sendSensors_freq;
+uint16_t sendUccm_freq; 
+
+std::mutex serialPort_lck;
+boost::asio::io_service io;
+boost::asio::serial_port serial(io);
 
 std::string readLine(boost::asio::serial_port &p)
 {
@@ -32,24 +48,21 @@ std::string readLine(boost::asio::serial_port &p)
     }
 }
 
-
-boost::asio::io_service io;
-boost::asio::serial_port serial(io,"/dev/ttyO4");
-
 void send(const std::string &data) {
-//    std::string message_length("AT+SBDWB=" + std::string(data.size()) + "\r");
+    // Send length of message
     std::string message_length("AT+SBDWB="+std::to_string(data.size())+"\r");
     boost::asio::write(serial,boost::asio::buffer(message_length.c_str(),message_length.size()));
 	
     std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
     
     auto data_c_str = data.c_str();
     int sum = 0;
-    for (int i = 0; i < data.length(); i++) {
-        sum += data_c_str[i];
+    for (unsigned int i = 0; i < data.length(); i++) {
+        sum += static_cast<uint8_t>(data_c_str[i]);
     }
 
+    // Check sum is lower two bytes of sum of the message 
     uint16_t check_sum_low = sum & 0x00FF;
     uint16_t check_sum_high = (sum & 0xFF00) >> 8;
 
@@ -61,16 +74,30 @@ void send(const std::string &data) {
     boost::asio::write(serial,boost::asio::buffer(message,message.size()));
     
     std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
 
     std::string send_command = "AT+SBDIX\r";
 
     boost::asio::write(serial,boost::asio::buffer(send_command,send_command.size()));
 
-	std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+}
+
+void receive_message(std::string& response, std::string status){
+    if (status == "1") {
+        std::string msg = "AT+SBDRT\r";
+        readLine(serial);
+        response = readLine(serial);
+    }
+    if (status == "2") {
+        response = "Error checking mailbox";
+    }
+    if (status == "0") {
+        std::string null_msg = "Mailbox empty";
+    }
 }
 
 void receive(){
@@ -85,7 +112,7 @@ void receive(){
     
     std::vector<std::string> trimmed_response;
 
-    for (int i = 0; i < response_split.size(); i++) {
+    for (unsigned int i = 0; i < response_split.size(); i++) {
         boost::algorithm::trim(response_split[i]);
     }
     
@@ -96,31 +123,88 @@ void receive(){
     std::cout << received_message <<std::endl;
 }
 
-void receive_message(std::string& response, std::string status){
-    if (status == "1") {
-        std::string msg = "AT+SBDRT\r";
-	    readLine(serial);
-        response = readLine(serial);
-    }
-    if (status == "2") {
-        response = "Error checking mailbox";
-    }
-    if (status == "0") {
-        std::string null_msg = "Mailbox empty";
+/* Callback function called when network table updated */
+void RootCallback(NetworkTable::Node node, \
+    std::map<std::string, NetworkTable::Value> diffs, \
+    bool is_self_reply) {
+    
+    // Store updated network table data 
+    NetworkTable::Sensors most_recent_sensorData;
+    NetworkTable::Uccms most_recent_uccmData;
+
+    most_recent_sensorData = NetworkTable::RootToSensors(&node);
+    most_recent_uccmData = NetworkTable::RootToUccms(&node);
+    most_recent_sensorData.SerializeToString(&most_recent_sensorData_string);
+    most_recent_uccmData.SerializeToString(&most_recent_uccmData_string);
+}
+
+/* Thread to send sensor data */
+void sendSensorData() {
+    std::cout << "started sensor thread" << std::endl;
+    while(true) {
+        if (most_recent_sensorData_string.size() != 0) {
+            std::cout << "sending sensor data" << std::endl;
+            serialPort_lck.lock();
+            send(most_recent_sensorData_string);
+            serialPort_lck.unlock();
+            sleep(sendSensors_freq);  
+        }
     }
 }
 
+/* Thread to send uccm data*/
+void sendUccmData() {
+    while(true) {
+        if (most_recent_uccmData_string.size() != 0) {
+            std::cout << "sending uccm data" << std::endl;
+            serialPort_lck.lock();
+            send(most_recent_uccmData_string);
+            serialPort_lck.unlock();
+            sleep(sendUccm_freq);  
+        }
+    }
+}
 
-int main() {
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        std::cout << "usage: ./rockblock <sensors send "\
+            << "frequency (seconds)> <uccm send frequency (seconds)> "\
+            << "<path to serial port>" << std::endl;
+        return 0;
+    }
+
+    sendSensors_freq = std::stoi(argv[1]);
+    sendUccm_freq = std::stoi(argv[2]);
+
+    std::string serialPort = argv[3];
+    serial.open(serialPort);
+
+    NetworkTable::Connection connection;
+    connection.SetTimeout(100);
+    try {
+        connection.Connect();
+    } catch (NetworkTable::TimeoutException) {
+        std::cout << "Failed to connect" << std::endl;
+        return 0;
+    }
+
+    most_recent_sensorData_string = "";
+    most_recent_uccmData_string = "";
+
+    connection.Subscribe("/", &RootCallback);
+
     serial.set_option(boost::asio::serial_port_base::baud_rate(19200));
     boost::asio::write(serial,boost::asio::buffer("AT\r",3));
-	std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
 
     boost::asio::write(serial,boost::asio::buffer("AT&K0\r",6));
-	std::cout << readLine(serial)<<std::endl;
-	std::cout << readLine(serial)<<std::endl;
-    
-   //send("hello");
-    receive();
+    std::cout << readLine(serial)<<std::endl;
+    std::cout << readLine(serial)<<std::endl;
+
+    std::thread sensorThread(sendSensorData);
+    std::thread uccmThread(sendUccmData);
+
+    sensorThread.join();
+    uccmThread.join();
 }


### PR DESCRIPTION
This commit sends Google Protobuf serialized Sensor and UCCM diagnostic data from the network table to the RockBlock. 

This is run on the BBB so that network table updates (intended to be received by an on-shore listener) can be sent to the rockblock. How often the data is sent is set by the two arguments passed in when starting the program. Sensor data is more useful and likely to be sent more often than uccm data. 

Note: testing has only been done using the virtual rockblock. Yet to be tested using the real rockblock. 
