### PR TITLE
NAV 69 Add/update READMEs

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -1,8 +1,9 @@
 # Projects
 > Build targets and target-specific code.
+Some projects have readmes with more information.
 
 ## Server
-Runs the network table server
+Runs the network table server.
 
 ## Client
 An example client of the Network Table.
@@ -10,10 +11,10 @@ This is also used to test the functionality of
 the NetworkTable.
 
 ## Viewtree
-Prints out all the values in the network table
+Prints out contents of the network table.
 
 ## Light Client
-Simply updates a single value in the network table forever
+Updates a single value in the network table forever.
 
 ## BBB Canbus Listener
 Reads data about various sensors on the canbus network
@@ -33,7 +34,7 @@ and places them in network table.
 Sends changes to sensor data in the network table to the NUC.
 
 ## BBB Rockblock Listener
-WIP. Sends/receives data over iridium satellite network
+Sends/receives data over iridium satellite network
 via a serial connection to Rockblock+.
 
 ## Land Satellite Listener

--- a/projects/bbb_ais_listener/README.md
+++ b/projects/bbb_ais_listener/README.md
@@ -1,0 +1,13 @@
+## BBB AIS Listener
+This program will listen for AIS data, and store that data into the network table.
+It does this by connecting to the [aisd program](https://github.com/UBCSailbot/ais/) via a ZeroMQ socket.
+BBB AIS Listener will periodically ask for a list of current boats in the area, and will overwrite
+the network table with the latest list of boats. This period is set to a default of 10 seconds,
+but can also be passed in via command line arguments.
+
+## Running
+**important**
+Make [aisd](https://github.com/UBCSailbot/ais/) is running, and the aisd antenna is connected.
+
+Here is an example of running the program, and overwriting the default period to 5 seconds.  
+```./bbb_ais_listener 5```

--- a/projects/bbb_canbus_listener/README.md
+++ b/projects/bbb_canbus_listener/README.md
@@ -1,0 +1,19 @@
+# BBB Canbus Listener
+Runs on the BBB and connects the CANbus network
+to the network table. Reads sensor data from the CANbus,
+and sends outputs from the controller (actuation angles)
+onto the CANbus network.
+
+## Setting up CANbus
+After you have physically set up the BBB (attached the canbus shield and connected
+it to the CANbus network), run the script (located in the top level scripts folder)  
+```config_canbus_pins.sh```  
+
+After running this, you should see a network interface called "can0"
+
+## Running
+This program requires the name of the network to interface to connect to.
+When using the real CANbus, it should be called "can0". However, during
+testing, a virtual canbus is also used called "vcan0".
+Here is an example of how to run the program when using the real CANbus:  
+```./bbb_canbus_listener can0```

--- a/projects/bbb_eth_listener/README.md
+++ b/projects/bbb_eth_listener/README.md
@@ -1,0 +1,23 @@
+## BBB Eth Listener
+This runs on the BBB, and connects the network table to the ethernet port.
+The ethernet port is connected to the NUC, which is running the controller/simulation
+code. This is used to transfer data to and from the controller/simulator.
+
+# Setting up 
+Of course, make sure there is a connection between the BBB and the Intel NUC.
+This is typically done via ethernet cable, although technically it is not
+required (the devices could communicate over a home wifi network as well).
+Before running, the ethernet port must appear as an active network interface.
+You can view active interfaces on the BBB with  
+```ifconfig```
+
+# Running
+Make sure to run the bbb_eth_listener first, before running the nuc_eth_listener
+For both programs, you must pass it the IP address of the BBB's ethernet port.
+
+For example, if the ip address of the ethernet port on the BBB is 192.168.1.25,
+and you decide to use port 5555 then on the BBB run:  
+```./bbb_eth_listener 192.168.1.25 5555```  
+
+After that, on the intel NUC, run:
+```./nuc_eth_listener 192.168.1.25 5555```

--- a/projects/bbb_rockblock_listener/README.md
+++ b/projects/bbb_rockblock_listener/README.md
@@ -1,0 +1,18 @@
+## BBB Rockblock Listener
+This sends sensor data over the satellite via a serial connection
+to a [Rockblock+](https://www.rock7.com/products/rockblock-iridium-9602-satellite-modem)
+
+For more info on using the rockblock, see [here](https://docs.rockblock.rock7.com/docs)
+Information about our iridium satellite usage, credits, etc [here](https://rockblock.rock7.com/Operations)
+
+This program will periodically send sensor data as well as uccm diagnostic data.
+These two data types can be sent at different rates (uccm data probably is not as important,
+and can be sent at a relatively lower frequency).
+
+## Running
+The program arguments are how often to send sensor data (in seconds),
+how often to send uccm data (in seconds), and the path to the serial port
+connected to the Rockblock.  
+Here is an example where sensors are sent every 30 seconds, and uccm every
+360 seconds, and serial port is at /dev/ttyUSB0
+```./bbb_rockblock_listener 60 360 /dev/ttyUSB0```

--- a/projects/bbb_rockblock_listener/main.cpp
+++ b/projects/bbb_rockblock_listener/main.cpp
@@ -189,7 +189,7 @@ void sendUccmData() {
 
 int main(int argc, char **argv) {
     if (argc != 4) {
-        std::cout << "usage: ./rockblock <sensors send "\
+        std::cout << "usage: ./bbb_rockblock_listener <sensors send "\
             << "frequency (seconds)> <uccm send frequency (seconds)> "\
             << "<path to serial port>" << std::endl;
         return 0;

--- a/projects/nuc_eth_listener/README.md
+++ b/projects/nuc_eth_listener/README.md
@@ -1,0 +1,10 @@
+## NUC Eth Listener
+This runs on the NUC, and connects the simulator/controller to the ethernet port.
+The ethernet port is connected to the BBB, which is then connected to the sensors/ais, etc.
+
+To build this, make sure the cmake variable ENABLE_ROS
+is set to ON, in the top level CMakeLists.txt
+
+# Running
+Pass the IP address of the beaglebone to this program.
+See [bbb_eth_listener](../bbb_eth_listener/README.md) for more info.

--- a/scripts/config_pins.sh
+++ b/scripts/config_pins.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Run this before running bbb_canbus_listener
+config-pin p9.19 can
+config-pin p9.20 can
+
+sudo ip link set can0 up type can bitrate 500000
+sudo ifconfig can0 up
+
+config-pin p9.11 uart
+config-pin p9.13 uart
+
+config-pin p9.24 uart
+config-pin p9.26 uart
+
+# print status of pins
+config-pin -q P9.19
+config-pin -q P9.20
+config-pin -q P9.11
+config-pin -q P9.13
+config-pin -q P9.24
+config-pin -q P9.26


### PR DESCRIPTION
Many of the project folders were missing READMEs,
and information about how to run these programs
was passed around on slack. This information
is now available for lookup in various READMEs.

Other changes include adding the config_pins.sh script
which sets up canbus on the BBB, and updated the usage
string in bbb_rockblock_listener.