### PR TITLE
NAV-19 Bidirectional communication between BBB and land server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "projects/bbb_ais_listener/ais"]
 	path = projects/bbb_ais_listener/ais
 	url = https://github.com/UBCSailbot/ais.git
+[submodule "projects/virtual_iridium"]
+	path = projects/virtual_iridium
+	url = https://github.com/UBCSailbot/virtual_iridium.git

--- a/projects/bbb_rockblock_listener/README.md
+++ b/projects/bbb_rockblock_listener/README.md
@@ -5,14 +5,130 @@ to a [Rockblock+](https://www.rock7.com/products/rockblock-iridium-9602-satellit
 For more info on using the rockblock, see [here](https://docs.rockblock.rock7.com/docs)
 Information about our iridium satellite usage, credits, etc [here](https://rockblock.rock7.com/Operations)
 
-This program will periodically send sensor data as well as uccm diagnostic data.
+This program will periodically send sensor data well as uccm diagnostic data.
 These two data types can be sent at different rates (uccm data probably is not as important,
 and can be sent at a relatively lower frequency).
 
+This program will also periodically receive global pathfinding waypoints.
+The frequency at which this data is received can be set as an argument. 
+
 ## Running
 The program arguments are how often to send sensor data (in seconds),
-how often to send uccm data (in seconds), and the path to the serial port
-connected to the Rockblock.  
+how often to send uccm data (in seconds), how often to receive waypoints,
+and the path to the serial port connected to the Rockblock.  
 Here is an example where sensors are sent every 30 seconds, and uccm every
-360 seconds, and serial port is at /dev/ttyUSB0
-```./bbb_rockblock_listener 60 360 /dev/ttyUSB0```
+360 seconds, and waypoints are received every 600 seconds, 
+and serial port is at /dev/ttyUSB0
+```./bbb_rockblock_listener 60 360 600 /dev/ttyUSB0```
+
+## Full Scale Testing with Viritual Iridium
+This will test Sending data from BBB to Viritual Iridium to Land Server
+as well as Sending data from Land Server to Virtual Iridium to BBB.
+
+The bbb_rockblock_listener will send dummy sensor and uccm data to the virtual rockblock via serial port.
+The virtual rockblock will relay the dummy sensor and uccm data to the land server via HTTP POST.
+
+The land_satellite_listener will send dummy waypoint data to the virtual rockblock via HTTP POSt.
+The virtual rockblock will relay the dummy waypoint data to bbb_rockblock_lisener via serial port.
+
+### Start the virtual iridium
+1. In a terminal, create a virtual serial port pair:
+```
+socat -d -d pty,raw,echo=0 pty,raw,echo=0
+```
+
+For example, the following serial devices will be created:
+```
+/dev/pts/3
+/dev/pts/4
+```
+
+2. In a new terminal start the virtual iridium using HTTP_POST mode:
+```
+python2 Iridium9602.py <LAND_SERVER_ENDPOINT> <SERVER_PORT_NUMBER> -d <SERIAL_DEVICE> -m HTTP_POST
+```
+
+<LAND_SERVER_ENDPOINT> is the ip/location of the land_satellite_listner server (ie. http://localhost:8000)
+
+<SERVER_PORT_NUMBER> is the port the iridium http handler will be running on (ie. 8080)
+
+<SERIAL_DEVICE> is one of the two socat pairs created in the previous step (ie. /dev/pts/3)
+
+### Start the land_satellite_listener
+1. In a terminal start the land_satellite_listener:
+```
+land_satellite_listener.py <SERVER_PORT_NUMBER> <VIRTUAL_IRIDIUM_ENDPOINT>
+```
+
+<SERVER_PORT_NUMBER> is the port the land http handler server will be running on (ie 8000)
+
+<VIRTUAL_IRIDIUM_ENDPOINT> is the ip/location of the server running in the virtual iridium (ie. http://localhost:8080)
+
+Note: This will cause dummy waypoint data to be sent and queued up in the virtual iridium.
+
+
+### Start the bbb_rockblock_listener
+1. Start the network table server
+```
+./server
+```
+
+2. Run the client
+```
+./client
+```
+
+3. Run the light client
+```
+./light-client
+```
+
+4. In a terminal start bbb_rockblock_listner:
+```
+./bbb_rockblock_listener <SENSOR_FREQ> <UCCM_FREQ> <REC_FREQ> <SERIAL_PORT>
+```
+
+<SENSOR_FREQ> is the frequency at which sensor data is sent
+
+<UCCM_FREQ> is the frequency at which uccm data is sent
+
+<REC_FREQ> is the frequency at which waypoint data is received
+
+<SERIAL_PORT> is the second socat pair device from setp 1 of starting the virtual iridium 
+
+For example:
+```
+./bbb_rockblock_listener 5 10 15 /dev/pts/4
+```
+
+This will send sensor data every 5 seconds, send uccm data every 10 seconds and receive waypoints every 10 seconds
+
+## Common Test Errors
+### Segfaults After Restarting bbb_rockblock_listener
+This might occur if you terminate the bbb_rockblock_listener code before all the contents of the serial port are read/removed.
+When you rerun bbb_rockblock_listener, it will be reading old serial messages/commands.
+
+To fix this:
+
+1. Terminate the virtual iridium and land_satellite_listener 
+
+In there respective terminals:
+```
+Ctr-C
+```
+
+2. Restart your socat pair
+```
+socat -d -d pty,raw,echo=0 pyt,raw,echo=0
+```
+
+3. Rerun virtual iridium and land_satellite_listener
+
+4. Rerun bbb_rockblock_listener
+
+### Terminating the Virtual Iridium:
+In cases where the order of running/terminating these programs is incorrect, you may need to run the following command in a separate terminal:
+```
+pkill python
+```
+

--- a/projects/land_satellite_listener/README.md
+++ b/projects/land_satellite_listener/README.md
@@ -8,10 +8,24 @@ satellite network. Decodes and prints the received
 data to the console. In the future, this script will 
 be modified to update the land-side database. 
 
-To run the script:  
-```python3 land_satellite_listener.py <SERVER_PORT_NUMBER>```
+This script also sends global pathfinding waypoints
+to the Iridium satellite network via HTTP POST request. 
 
-## Testing
+Install protobuf for python3:  
+```pip3 install protobuf```
+
+To run the script:  
+```python3 land_satellite_listener.py <SERVER_PORT_NUMBER> <HTTP_POST_ENDPOINT>```
+
+For example:
+```
+python3 land_satellite_listener.py 8000 https://rockblock.rock7.com/rockblock/MT
+```
+
+## Full-Scale Testing 
+Refer to bbb_rockblock_listener README for full-scale testing with the virtual rockblock.
+
+## Small-Scale Testing
 `sensorBinaryData.txt` contains serialized dummy sensor
 data from the network table that can be sent as test 
 data to the http server via post request. 

--- a/projects/land_satellite_listener/land_satellite_listener.py
+++ b/projects/land_satellite_listener/land_satellite_listener.py
@@ -1,36 +1,78 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
+import http.server
 import sys
+import requests
+import _thread
+import threading
+import time
 sys.path.append('generated_python/')
 
 import Sensors_pb2
 import Uccms_pb2
 import Satellite_pb2
+import Value_pb2
 
 class HTTPRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         print("Handling post request")
         content_len = int(self.headers['Content-Length']) 
         body = self.rfile.read(content_len)
-        satellite = Satellite_pb2.Satellite()
+        sat = Satellite_pb2.Satellite()
 
         try:
-            satellite.ParseFromString(body)
-            if satellite.type == Satellite_pb2.Satellite.Type.SENSORS:
+            sat.ParseFromString(body)
+            if sat.type == Satellite_pb2.Satellite.Type.SENSORS:
                 print("Receiving Sensor Data")
-                print(satellite.sensors)
-            elif satellite.type == Satellite_pb2.Satellite.Type.UCCMS:
+                print(sat.sensors)
+            elif sat.type == Satellite_pb2.Satellite.Type.UCCMS:
                 print("Receiving UCCM Data")
-                print(satellite.uccms)
+                print(sat.uccms)
+            elif sat.type == Satellite_pb2.Satellite.Type.VALUE:
+                print("Receiving Waypoint Data")
+                print(sat.value)
             else:
                 print("Did Not receive Sensor or UCCM data")
+                print(body)
+
+            self.send_response(200)           
+            self.end_headers()
 
         except IOError:
             print("Error Decoding incoming data") 
 
-if len(sys.argv) != 2:
-    print("usage: python3 land_receive <server port>")
+class runServer(threading.Thread):
+    def __init__(self, port):
+        threading.Thread.__init__(self)
+        self.port = port
+    def run(self):
+        httpd = HTTPServer(("", self.port), HTTPRequestHandler)
+        httpd.serve_forever()
+
+class runClient(threading.Thread):
+    def run(self):
+        sat = Satellite_pb2.Satellite()
+        sat.type = Satellite_pb2.Satellite.Type.VALUE
+        sat.value.type = Value_pb2.Value.Type.WAYPOINTS
+        gpsCoord1 = sat.value.waypoints.add()
+        gpsCoord1.latitude = 1.1
+        gpsCoord1.longitude = 1.1
+        gpsCoord1 = sat.value.waypoints.add()
+        gpsCoord1.latitude = 1.2
+        gpsCoord1.longitude = 1.2
+        for x in range(20):
+            requests.post(ENDPOINT, data=sat.SerializeToString())
+            time.sleep(2)            
+
+if len(sys.argv) != 3:
+    print("usage: python3 land_receive <server port> <HTTP_POST Endpoint>")
 
 else:
     print("serving at port", sys.argv[1])
-    httpd = HTTPServer(("", int(sys.argv[1])), HTTPRequestHandler)
-    httpd.serve_forever()
+    port = int(sys.argv[1])
+    ENDPOINT = sys.argv[2]
+
+    server = runServer(port)
+    client = runClient()
+    server.start()
+    client.start()
+

--- a/src/protofiles/Satellite.proto
+++ b/src/protofiles/Satellite.proto
@@ -4,6 +4,7 @@ package NetworkTable;
 
 import "Sensors.proto";
 import "Uccms.proto";
+import "Value.proto";
 
 /*
  * This is sent across the satellite
@@ -14,9 +15,11 @@ message Satellite {
 
     Sensors sensors = 2;
     Uccms uccms = 3;
+    Value value = 4;
 
     enum Type {
         SENSORS = 0;
         UCCMS = 1;
+        VALUE = 2;
     }
 }

--- a/src/protofiles/Value.proto
+++ b/src/protofiles/Value.proto
@@ -10,6 +10,7 @@ message Value {
     string string_data = 5;
     bytes bytes_data = 6;
     repeated Boat boats = 7;
+    repeated Waypoint waypoints = 8;
 
     enum Type {
          FLOAT = 0;
@@ -18,6 +19,7 @@ message Value {
          STRING = 3;
          BYTES = 4;
          BOATS = 5;
+         WAYPOINTS = 6;
     }
 
     message Boat {
@@ -42,5 +44,10 @@ message Value {
         bool m_positionValid = 17;
         bool m_timeStampValid = 18;
         int32 m_transcieverClass = 19;
+    }
+    
+    message Waypoint {
+        double latitude = 1;
+        double longitude = 2;
     }
 }


### PR DESCRIPTION
This commit includes two projects: 
bbb_rockblock_listener and land_satellite_listener
and completes the bidirectional transfer of data
between the BBB and land server with the rockblock
as a middle man. 

Sensor and UCCM diagnostic data is sent from the BBB
to the rockblock via serial connection. The rockblock 
relays this data to the land server via HTTP_POST request.

Waypoints are sent from the land server to the rockblock
via HTTP_POST. The rockblock relays this data to the 
BBB via serial connection. 

Note: Testing has only been done with dummy data and the 
virtual iridium, yet to be tested with the actual rockblock.
Both projects will likely be updated to write data to their
respective network tables. 
