### PR TITLE
NAV-128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,17 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10.0)
 
 set(CMAKE_C_COMPILER "clang")
 set(CMAKE_CXX_COMPILER "clang++")
 # If you set this to ON, make sure you
 # have installed ROS and catkin is in your path.
-set(ENABLE_ROS OFF CACHE BOOL OFF)
+set(ENABLE_ROS OFF CACHE BOOL
+    "Compile executables which require ROS?")
+
+# If you're changing this,
+# make sure to escape string properly. ex:
+# cmake .. -DWELCOME_DIRECTORY="\"/tmp/banana/\""
+set(WELCOME_DIRECTORY "\"/tmp/sailbot/\"" CACHE STRING
+    "Where the network table stores its data")
 
 project(network-table CXX)
 

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ The directories `src` and `test/basic_tests` should mirror each other. That is, 
 -   **scripts/** - Scripts used for various purposes. View the comments at the top of the scripts to learn what they do.
 -   **test/** - Unit tests. These test specific functionality of the network-table.
 -   **projects/** - Target specific code. For more details, check the README file in this directory.
--   **Jenkins/** - Jenkins scripts for running automated tests.
+-   **jenkins/** - Jenkins scripts for running automated tests.

--- a/jenkins/can_bbb_nuc_integration.jenkinsfile
+++ b/jenkins/can_bbb_nuc_integration.jenkinsfile
@@ -29,10 +29,18 @@ pipeline {
                             checkout scm
                             // TODO: Should run make clean here, but the BBB
                             // is soo slow
+                            //
+                            // Also the WELCOME_DIRECTORY needs to be escaped a bunch of times:
+                            // once for the jenkins file, and then another time
+                            // when its called from cmake. When it finally
+                            // ends up in the C++, it should be in the form
+                            // #define WELCOME_DIRECTORY "/tmp/can_bbb_nuc_integration/"
+                            // the number of backslashes to use I found out using trial
+                            // and error :(
                             sh '''
                                 mkdir -p build
                                 cd build
-                                cmake ..
+                                cmake .. -DWELCOME_DIRECTORY="\\\"/tmp/can_bbb_nuc_integration/\\\""
                                 make
                             '''
                         }
@@ -48,6 +56,8 @@ pipeline {
                         // specifically we want nuc_eth_listener
                         dir('/home/raye/workspace/can_bbb_nuc_integration') {
                             checkout scm
+                            // We're not running network_table_server here,
+                            // so we don't need the WELCOME_DIRECTORY flag
                             sh '''
                                 set +x
                                 source /opt/ros/melodic/setup.bash
@@ -141,7 +151,7 @@ def cleanup() {
             sh 'pkill -f bbb_eth_listener'
             sh 'pkill -f bbb_canbus_listener'
             sh 'pkill -f mock_sensors'
-            sh 'rm -r /tmp/sailbot'
+            sh 'rm -r /tmp/can_bbb_nuc_integration/'
         }
     }
     // Cleanup processes on NUC

--- a/scripts/network_table_stress_test.py
+++ b/scripts/network_table_stress_test.py
@@ -55,8 +55,11 @@ def run_server_and_fake_crashes():
     os.killpg(os.getpgid(server.pid), signal.SIGTERM)
 
 
-def run_python_client():
-    nt_connection = Connection()
+def run_python_client(welcome_dir):
+    if welcome_dir is not None:
+        nt_connection = Connection(welcome_dir)
+    else:
+        nt_connection = Connection()
     nt_connection.Connect()
 
     num_queries = 10
@@ -122,12 +125,20 @@ if __name__ == '__main__':
         "--python-client", help="Runs the python client\
                 instead of the C++ client",
         action='store_true')
+
+    # note that this is only needed by python. The C++ code
+    # automatically does this with a define statement set by cmake.
+    parser.add_argument(
+        "--python-client-welcome-dir", help="When running the python client,\
+                this determines which network table to connect to",
+        type=str)
     args = parser.parse_args()
 
     num_clients = args.num_clients
     disable_fake_crashes = args.disable_fake_crashes
     clients_only = args.clients_only
     python_client = args.python_client
+    python_client_welcome_dir = args.python_client_welcome_dir
     build = args.compile  # variable name compile is not allowed
 
     # Go to the build directory
@@ -152,7 +163,8 @@ if __name__ == '__main__':
         server_thread.start()
 
     if python_client:
-        clients = [Thread(target=run_python_client)
+        clients = [Thread(target=run_python_client, args=(
+                        python_client_welcome_dir,))
                    for i in range(num_clients)]
 
         for client in clients:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,5 +42,7 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
 
 add_library(nt_server STATIC ${NT_SERVER_SRCS} ${NT_SERVER_HDRS} ${PROTO_SRCS} ${PROTO_HDRS})
 add_library(nt_client STATIC ${NT_CLIENT_SRCS} ${NT_CLIENT_HDRS} ${PROTO_SRCS} ${PROTO_HDRS})
+target_compile_definitions(nt_client PUBLIC WELCOME_DIRECTORY=${WELCOME_DIRECTORY})
+target_compile_definitions(nt_server PUBLIC WELCOME_DIRECTORY=${WELCOME_DIRECTORY})
 
 add_subdirectory(python)

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -288,7 +288,7 @@ void NetworkTable::Connection::ManageSocket(int timeout_millis) {
         // send/receive:
         init_socket.setsockopt(ZMQ_LINGER, 0);
         init_socket.setsockopt(ZMQ_RCVTIMEO, timeout_millis);
-        init_socket.connect("ipc:///tmp/sailbot/NetworkTable");
+        init_socket.connect("ipc://" + kWelcome_Directory_ + "NetworkTable");
 
         {
             // The request body must be "connect"

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -144,6 +144,9 @@ class Connection {
         void(*)(NetworkTable::Node, \
                const std::map<std::string, NetworkTable::Value> &, \
                bool)> callbacks_;
+
+    // location of welcoming socket
+    const std::string kWelcome_Directory_ = WELCOME_DIRECTORY;  // NOLINT(runtime/string)
 };
 
 /*

--- a/src/Server.h
+++ b/src/Server.h
@@ -22,21 +22,6 @@ namespace NetworkTable {
 class Server {
 typedef std::shared_ptr<zmq::socket_t> socket_ptr;
 
-// location of welcoming socket
-const std::string  kWelcome_Directory_ = "/tmp/sailbot/";  // NOLINT(runtime/string)
-
-// location of client sockets
-const std::string kClients_Directory_ = kWelcome_Directory_ + "clients/";  // NOLINT(runtime/string)
-
-// where root_ is saved (in case of crash)
-const std::string kRootFilePath_ = kWelcome_Directory_ + "root_.txt";  // NOLINT(runtime/string)
-
-// where info about who is subcribed to what is saved (in case of crash)
-// sorry for stupid NOLINT stuff, it has to be on the same
-// line as the lint error. try to ignore it
-const std::string kSubscriptionsTableFilePath_ = /* NOLINT(runtime/string) */\
-    kWelcome_Directory_  + "subscriptions_table_.txt";
-
  public:
     Server();
 
@@ -142,6 +127,21 @@ const std::string kSubscriptionsTableFilePath_ = /* NOLINT(runtime/string) */\
     std::unordered_map<std::string, \
         std::set<socket_ptr>> subscriptions_table_;  // maps from a key in the network table
                                                       // to a set of sockets subscribe to that key.
+
+    // location of welcoming socket
+    const std::string kWelcome_Directory_ = WELCOME_DIRECTORY;  // NOLINT(runtime/string)
+
+    // location of client sockets
+    const std::string kClients_Directory_ = kWelcome_Directory_ + "clients/";  // NOLINT(runtime/string)
+
+    // where root_ is saved (in case of crash)
+    const std::string kRootFilePath_ = kWelcome_Directory_ + "root_.txt";  // NOLINT(runtime/string)
+
+    // where info about who is subcribed to what is saved (in case of crash)
+    // sorry for stupid NOLINT stuff, it has to be on the same
+    // line as the lint error. try to ignore it
+    const std::string kSubscriptionsTableFilePath_ = /* NOLINT(runtime/string) */\
+        kWelcome_Directory_  + "subscriptions_table_.txt";
 };
 }  // namespace NetworkTable
 

--- a/src/python/Connection.py
+++ b/src/python/Connection.py
@@ -17,10 +17,17 @@ class Connection:
     This is the python implementation of Connection.h
     """
 
-    def __init__(self):
+    def __init__(self, welcome_dir='/tmp/sailbot/'):
+        """The default location to connect to is in
+        the /tmp/sailbot/ folder. However, for certain tests,
+        we change this so that we can run a network table
+        without messing with anyone doing development and using
+        the default location.
+        """
         self.context = zmq.Context()
         self.socket = None
         self.connected = False
+        self.welcome_dir = welcome_dir
 
     def Connect(self):
         """Initiates connection to the network table server
@@ -32,7 +39,7 @@ class Connection:
 
         # Send a request to connect to the network table
         init_socket = self.context.socket(zmq.REQ)
-        init_socket.connect('ipc:///tmp/sailbot/NetworkTable')
+        init_socket.connect('ipc://{}NetworkTable'.format(self.welcome_dir))
         # make sure to null terminate strings
         init_socket.send(b'connect\x00')
 


### PR DESCRIPTION
WELCOME_DIRECTORY is a preprocessor statement
that can be used to set the network tables "welcome directory" at
compile time. This is where the network table stores all its
information, like sockets, files, etc. This allows multiple network
tables to run at the same time, as long as they're using different
directories.

The clients also use WELCOME_DIRECTORY to determine where/which
network table to connect to.

This can be set when calling cmake. Make sure quotations are escaped
properly. ex:
cmake .. -DWELCOME_DIRECTORY="\"/tmp/banana/\""