### PR TITLE
NAV-139 Unsubscribe clients who have disconnected

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -274,6 +274,8 @@ void NetworkTable::Server::DisconnectSocket(socket_ptr socket) {
         entry.second.erase(socket);
     }
 
+    WriteSubscriptionTable();
+
     {
         // Remove the socket from our list of sockets to poll
         // and delete it.


### PR DESCRIPTION
Was forgetting to write the subscriptions table after modifying it. This would cause the next instance of network table to try to send updates to clients who dont exist