### PR TITLE
NAV-147 Non-protobuf network table connection api

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,11 +15,13 @@ set(NT_SERVER_HDRS
 set(NT_CLIENT_SRCS
         Connection.cpp
         Help.cpp
+        NonProtoConnection.cpp
         )
 
 set(NT_CLIENT_HDRS
         Connection.h
         Help.h
+        NonProtoConnection.h
         )
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS

--- a/src/NonProtoConnection.cpp
+++ b/src/NonProtoConnection.cpp
@@ -1,0 +1,124 @@
+// Copyright 2017 UBC Sailbot
+
+#include "NonProtoConnection.h"
+
+#include <stdio.h>
+#include <string.h>
+
+
+////////////////////// PUBLIC //////////////////////
+
+NetworkTable::NonProtoConnection::NonProtoConnection() {
+}
+
+void NetworkTable::NonProtoConnection::SetIntValue(const std::string &uri, const int &value) {
+    std::map<std::string, int> values = {{uri, value}};
+    SetIntValues(values);
+}
+
+void NetworkTable::NonProtoConnection::SetIntValues(const std::map<std::string, int> &values) {
+    std::map<std::string, NetworkTable::Value> proto_values;
+    for (auto const &entry : values) {
+        std::string uri = entry.first;
+        NetworkTable::Value int_val;
+        int_val.set_type(NetworkTable::Value::INT);
+        int_val.set_int_data(entry.second);
+        proto_values[uri] = int_val;
+    }
+
+    SetValues(proto_values);
+}
+
+void NetworkTable::NonProtoConnection::SetFloatValue(const std::string &uri, const float &value) {
+    std::map<std::string, float> values = {{uri, value}};
+    SetFloatValues(values);
+}
+
+void NetworkTable::NonProtoConnection::SetFloatValues(const std::map<std::string, float> &values) {
+    std::map<std::string, NetworkTable::Value> proto_values;
+    for (auto const &entry : values) {
+        std::string uri = entry.first;
+        NetworkTable::Value float_val;
+        float_val.set_type(NetworkTable::Value::FLOAT);
+        float_val.set_float_data(entry.second);
+        proto_values[uri] = float_val;
+    }
+
+    SetValues(proto_values);
+}
+
+void NetworkTable::NonProtoConnection::SetStringValue(const std::string &uri, const std::string &value) {
+    std::map<std::string, std::string> values = {{uri, value}};
+    SetStringValues(values);
+}
+
+void NetworkTable::NonProtoConnection::SetStringValues(const std::map<std::string, std::string> &values) {
+    std::map<std::string, NetworkTable::Value> proto_values;
+    for (auto const &entry : values) {
+        std::string uri = entry.first;
+        NetworkTable::Value string_val;
+        string_val.set_type(NetworkTable::Value::STRING);
+        string_val.set_string_data(entry.second);
+        proto_values[uri] = string_val;
+    }
+
+    SetValues(proto_values);
+}
+
+void NetworkTable::NonProtoConnection::SetBooleanValue(const std::string &uri, const bool &value) {
+    std::map<std::string, bool> values = {{uri, value}};
+    SetBooleanValues(values);
+}
+
+void NetworkTable::NonProtoConnection::SetBooleanValues(const std::map<std::string, bool> &values) {
+    std::map<std::string, NetworkTable::Value> proto_values;
+    for (auto const &entry : values) {
+        std::string uri = entry.first;
+        NetworkTable::Value bool_val;
+        bool_val.set_type(NetworkTable::Value::BOOL);
+        bool_val.set_bool_data(entry.second);
+        proto_values[uri] = bool_val;
+    }
+
+    SetValues(proto_values);
+}
+
+void NetworkTable::NonProtoConnection::SetWaypointValue(const std::pair<double, double> &value) {
+    std::list<std::pair<double, double>> coordinates;
+    coordinates.push_back(value);
+
+    SetWaypointValues(coordinates);
+}
+
+void NetworkTable::NonProtoConnection::SetWaypointValues(std::list<std::pair<double, double>> &values) {
+    std::map<std::string, NetworkTable::Value> proto_values;
+    std::string uri = "waypoints";
+    NetworkTable::Value waypoints_val;
+    waypoints_val.set_type(NetworkTable::Value::WAYPOINTS);
+
+    for (auto const &coordinates : values) {
+        NetworkTable::Value_Waypoint *waypoint = waypoints_val.add_waypoints();
+        waypoint->set_latitude(coordinates.first);
+        waypoint->set_longitude(coordinates.second);
+    }
+    proto_values[uri] = waypoints_val;
+
+    SetValues(proto_values);
+}
+
+std::list<std::pair<double, double>> NetworkTable::NonProtoConnection::GetCurrentWaypoints() {
+    NetworkTable::Value waypoints_val;
+    const std::string uri = "waypoints";
+    std::list<std::pair<double, double>> coordinates;
+
+    waypoints_val = GetValue(uri);
+
+    for (auto const &coord : waypoints_val.waypoints()) {
+        std::pair<double, double> curr_coord;
+        curr_coord.first = coord.latitude();
+        curr_coord.second = coord.longitude();
+        coordinates.push_back(curr_coord);
+    }
+
+    return coordinates;
+}

--- a/src/NonProtoConnection.h
+++ b/src/NonProtoConnection.h
@@ -1,0 +1,108 @@
+// Non-proto Connection.h
+// Copyright 2017 UBC Sailbot
+
+#ifndef NONPROTOCONNECTION_H_
+#define NONPROTOCONNECTION_H_
+
+#include "Connection.h"
+#include "Exceptions.h"
+#include "Node.pb.h"
+#include "Value.pb.h"
+
+#include <exception>
+#include <map>
+#include <string>
+#include <utility>
+#include <list>
+
+namespace NetworkTable{
+class NonProtoConnection : public Connection {
+ public:
+    NonProtoConnection();
+
+    /*
+     * Set Integer value in the network table, or create
+     * it if it doesn't exist.
+     */
+    void SetIntValue(const std::string &uri, const int &values);
+
+    /*
+     * Set multiple Integer values in the network table, or create
+     * them if they don't exist.
+     * @param values - map from string to Value, where the string
+     *                 is the uri, and Value is what to set the
+     *                 value at that uri to.
+     */
+    void SetIntValues(const std::map<std::string, int> &values);
+
+    /*
+     * Set Float value in the network table, or create
+     * it if it doesn't exist.
+     */
+    void SetFloatValue(const std::string &uri, const float &values);
+
+    /*
+     * Set multiple Float values in the network table, or create
+     * them if they don't exist.
+     * @param values - map from string to Value, where the string
+     *                 is the uri, and Value is what to set the
+     *                 value at that uri to.
+     */
+    void SetFloatValues(const std::map<std::string, float> &values);
+
+    /*
+     * Set String value in the network table, or create
+     * it if it doesn't exist.
+     */
+    void SetStringValue(const std::string &uri, const std::string &values);
+
+    /*
+     * Set multiple String values in the network table, or create
+     * them if they don't exist.
+     * @param values - map from string to Value, where the string
+     *                 is the uri, and Value is what to set the
+     *                 value at that uri to.
+     */
+    void SetStringValues(const std::map<std::string, std::string> &values);
+
+    /*
+     * Set Boolean value in the network table, or create
+     * it if it doesn't exist.
+     */
+    void SetBooleanValue(const std::string &uri, const bool &values);
+
+    /*
+     * Set multiple Boolean values in the network table, or create
+     * them if they don't exist.
+     * @param values - map from string to Value, where the string
+     *                 is the uri, and Value is what to set the
+     *                 value at that uri to.
+     */
+    void SetBooleanValues(const std::map<std::string, bool> &values);
+
+    /*
+     * Set gps Waypoint value in the network table, or create
+     * it if it doesn't exist.
+     */
+    void SetWaypointValue(const std::pair<double, double> &value);
+
+    /*
+     * Set multiple gps Waypoint values in the network table, or create
+     * them if they don't exist.
+     * @param values - map from string to Value, where the string
+     *                 is the uri, and Value is what to set the
+     *                 value at that uri to.
+     */
+    void SetWaypointValues(std::list<std::pair<double, double>> &values);
+
+
+    /*
+     * Returns the current gps coordinates  
+     */
+    std::list<std::pair<double, double>> GetCurrentWaypoints(); 
+
+};
+
+}  // namespace NetworkTable
+
+#endif  // NONPROTOCONNECTION_H_


### PR DESCRIPTION
NonProtoConnection subclasses 
the Connection class. Includes
wrapper functions that do not require
protobuf object as parameters or return 
values when setting/getting values from 
the network table. 

Currently contains a  GetCurrentWaypoints 
function rather than a generalized 
GetValues function.

Note: These wrapper functions do not 
catch the exceptions thrown by the 
original Connection.cpp functions. 