### PR TITLE
Memory leak fixes

### DIFF
--- a/projects/client/main.cpp
+++ b/projects/client/main.cpp
@@ -61,6 +61,9 @@ int main() {
     NetworkTable::Connection connection;
     try {
         connection.Connect(5000);
+    } catch (NetworkTable::InterruptedException) {
+        std::cout << "Received interrupt signal" << std::endl;
+        return 0;
     } catch (NetworkTable::TimeoutException) {
         std::cout << "Connection to server timed out" << std::endl;
         return 0;

--- a/projects/network_table_server/main.cpp
+++ b/projects/network_table_server/main.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 UBC Sailbot
 
 #include "Server.h"
+#include "Exceptions.h"
 
 #include <iostream>
 
@@ -9,5 +10,9 @@ int main() {
     // WELCOME_DIRECTORY passed in as a compile flag
     // from cmake. You won't find its definition in the code
     std::cout << "Network table is running at " << WELCOME_DIRECTORY << std::endl;
-    server.Run();
+    try {
+        server.Run();
+    } catch (NetworkTable::InterruptedException) {
+        std::cout << "Network table DONE" << std::endl;
+    }
 }

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -129,6 +129,12 @@ class Connection {
      */
     void WaitForAck();
 
+    /*
+     * Helper function which sends a message
+     * to our background thread telling it to die.
+     */
+    void InterruptManageSocketThread();
+
     void ManageSocket(int timeout_millis, bool async);
 
     zmq::context_t context_;

--- a/src/Exceptions.h
+++ b/src/Exceptions.h
@@ -18,6 +18,11 @@ public:
     explicit NodeNotFoundException(const std::string &what) : std::runtime_error(what.c_str()) { };
 };
 
+class InterruptedException : public std::runtime_error {
+public:
+    explicit InterruptedException(const std::string &what) : std::runtime_error(what.c_str()) { };
+};
+
 }  // namespace NetworkTable
 
 #endif  // EXCEPTIONS_H_


### PR DESCRIPTION
Added code to handle SIGINT and gracefully terminate.
Without this, valgrind will report a memory leak when ctrl-c'ing the
server or connection.

Removed all calls to "new" in Server.cpp and Connection.cpp

The goal is to be able to use valgrind to test for memory leaks.
First step though is to remove all the current memory leaks.
This removes all leaks (detected by valgrind) in "network_table_server"
and "client" projects. I have not yet tested the other projects.