### PR TITLE
NAV-164 Nonproto get gps coords function

### DIFF
--- a/projects/light_client/main.cpp
+++ b/projects/light_client/main.cpp
@@ -20,6 +20,16 @@ int main() {
     }
 
     int val = 4;
+    int lat = 48;
+    int lon = 235;
+    NetworkTable::Value lat_val;
+    lat_val.set_type(NetworkTable::Value::INT);
+    NetworkTable::Value lon_val;
+    lon_val.set_type(NetworkTable::Value::INT);
+    lat_val.set_int_data(lat);
+    lon_val.set_int_data(lon);
+    connection.SetValue("gps/gprmc/longitude", lon_val);
+    connection.SetValue("gps/gprmc/latitude", lat_val);
     while (true) {
         NetworkTable::Value value;
         value.set_type(NetworkTable::Value::INT);

--- a/src/NonProtoConnection.cpp
+++ b/src/NonProtoConnection.cpp
@@ -84,13 +84,13 @@ void NetworkTable::NonProtoConnection::SetBooleanValues(const std::map<std::stri
 }
 
 void NetworkTable::NonProtoConnection::SetWaypointValue(const std::pair<double, double> &value) {
-    std::list<std::pair<double, double>> coordinates;
+    std::vector<std::pair<double, double>> coordinates;
     coordinates.push_back(value);
 
     SetWaypointValues(coordinates);
 }
 
-void NetworkTable::NonProtoConnection::SetWaypointValues(const std::list<std::pair<double, double>> &values) {
+void NetworkTable::NonProtoConnection::SetWaypointValues(const std::vector<std::pair<double, double>> &values) {
     std::map<std::string, NetworkTable::Value> proto_values;
     std::string uri = "waypoints";
     NetworkTable::Value waypoints_val;
@@ -121,4 +121,19 @@ std::list<std::pair<double, double>> NetworkTable::NonProtoConnection::GetCurren
     }
 
     return coordinates;
+}
+
+std::pair<double, double> NetworkTable::NonProtoConnection::GetCurrentGpsCoords() {
+    const std::string lat_uri = "gps/gprmc/latitude";
+    const std::string lon_uri = "gps/gprmc/longitude";
+
+    double lat, lon;
+    std::pair<double, double> curr_gps;
+    lat = GetValue(lat_uri).int_data();
+    lon = GetValue(lon_uri).int_data();
+
+    curr_gps.first = lat;
+    curr_gps.second = lon;
+
+    return curr_gps;
 }

--- a/src/NonProtoConnection.h
+++ b/src/NonProtoConnection.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <utility>
 #include <list>
+#include <vector>
 
 namespace NetworkTable{
 class NonProtoConnection : public Connection {
@@ -93,13 +94,18 @@ class NonProtoConnection : public Connection {
      *                 is the uri, and Value is what to set the
      *                 value at that uri to.
      */
-    void SetWaypointValues(const std::list<std::pair<double, double>> &values);
+    void SetWaypointValues(const std::vector<std::pair<double, double>> &values);
 
 
     /*
-     * Returns the current gps coordinates  
+     * Returns the current gps waypoint coordinates  
      */
     std::list<std::pair<double, double>> GetCurrentWaypoints(); 
+
+	/* 
+	 * Returns current gps location
+	 */
+    std::pair<double, double> GetCurrentGpsCoords(); 
 
 };
 


### PR DESCRIPTION
Nonproto Connection api now
contains a GetCurrentGpsCoords()
function. Return gps lat/lon data
stored at gps/gprmc/latitude and 
gps/gprmc/longitude in the network
table. 

Function to set waypoint data in nt
now takes in a vector of coordinates 
instead of a list to be compatible with 
global pathfinding data.