### PR TITLE
Fix Boom Sensor URI

### DIFF
--- a/src/Help.cpp
+++ b/src/Help.cpp
@@ -339,7 +339,7 @@ NetworkTable::Node NetworkTable::SensorsToRoot(const NetworkTable::Sensors &sens
     try {
         val.set_type(NetworkTable::Value::INT);
         val.set_int_data(sensors.boom_angle_sensor().sensor_data().angle());
-        SetNode("/boom_angle_sensor/boom_angle_sensor/angle", val, &root);
+        SetNode("/boom_angle_sensor/sensor_data/angle", val, &root);
     } catch (const NetworkTable::NodeNotFoundException &e) {
     }
 

--- a/src/python/Help.py
+++ b/src/python/Help.py
@@ -32,7 +32,7 @@ class Help:
         # Store boom sensor values
         val = self.create_int_val(
             sensors.boom_angle_sensor.sensor_data.angle)
-        values["/boom_angle_sensor/boom_angle_sensor/angle"] = val
+        values["/boom_angle_sensor/sensor_data/angle"] = val
 
         # Store wind sensor values
         val = self.create_int_val(sensors.wind_sensor_0.iimwv.wind_speed)


### PR DESCRIPTION
RootToSensors and SensorsToRoot now reference the same boom sensor URI in the python and cpp interfaces.
ie. the boom sensor angle data is now set and retrieved from the same node. 