### PR TITLE
Added print out for local_pathfinding on NUC 

### DIFF
--- a/jenkins/can_bbb_nuc_integration.jenkinsfile
+++ b/jenkins/can_bbb_nuc_integration.jenkinsfile
@@ -124,7 +124,6 @@ pipeline {
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/network_table_server > network_table_server.log &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_eth_listener 192.168.1.60 5555 > bbb_eth_listener.log &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_canbus_listener vcan0 > bbb_canbus_listener.log &'
-                            sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_satellite_listener 2 2 2 /tmp/serialport1 > bbb_satellite_listener.log &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./projects/virtual_iridium/python/Iridium9602.py --webhook_server_endpoint 10.0.0.1:8000 --http_server_port 8085 -d /tmp/serialport2 -m HTTP_POST > virtual_iridium.log &'
 
                             // Run this here so that we have gps coordinates in the network table and global pathfinding will work properly
@@ -184,6 +183,18 @@ pipeline {
                     }
                 }
 
+                stage('Run BBB Satellite Listener') {
+                    agent {
+                        label 'bbb'
+                    }
+                    steps {
+                        dir("/home/debian/workspace/can_bbb_nuc_integration/") {
+                            sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_satellite_listener 2 2 2 /tmp/serialport1 > bbb_satellite_listener.log &'
+                        }
+                    }
+                }
+
+
                 stage ('Run BBB tests') {
                     agent {
                         label 'bbb'
@@ -191,6 +202,7 @@ pipeline {
                     steps {
                         dir("/home/debian/workspace/can_bbb_nuc_integration/") {
                             sh './scripts/canbus_data_checker.py -c vcan0'
+							sh './build/bin/viewtree'
                         }
                     }
                 }

--- a/jenkins/can_bbb_nuc_integration.jenkinsfile
+++ b/jenkins/can_bbb_nuc_integration.jenkinsfile
@@ -141,26 +141,30 @@ pipeline {
                             sh '''
                                 set +x
                                 source /opt/ros/melodic/setup.bash
+                                set -x
                                 JENKINS_NODE_COOKIE=nokill nohup /opt/ros/melodic/bin/roscore &
                             '''
                             // roscore takes a while to startup.
                             // without this, nuc_eth_listener may get "failed to contact master"
                             sleep(5)
                             sh '''
-                                set +x
+                                set +x 
                                 source /opt/ros/melodic/setup.bash
+                                set -x
                                 JENKINS_NODE_COOKIE=nokill nohup ./build/bin/nuc_eth_listener 192.168.1.60 5555 > nuc_eth_listener.log &
                             '''
                             sh '''
                                 set +x
                                 source /opt/ros/melodic/setup.bash
                                 source /home/raye/catkin_ws/devel/setup.sh
+                                set -x
                                 JENKINS_NODE_COOKIE=nokill nohup /opt/ros/melodic/bin/rosrun raye_communication raye_communication_node &
                             '''
                             sh '''
                                 set +x
                                 source /opt/ros/melodic/setup.bash
                                 source /home/raye/catkin_ws/devel/setup.sh
+                                set -x
                                 JENKINS_NODE_COOKIE=nokill nohup /opt/ros/melodic/bin/rosrun local_pathfinding main_loop.py &
                             '''
                         }


### PR DESCRIPTION
Just added 'set -x' after source commands on the NUC pipeline step so that it avoids printing out the source output but still prints out any potential output coming from running the local_pathfinding command.