### PR TITLE
Add local-pathfinding as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "projects/global-pathfinding"]
 	path = projects/global-pathfinding
 	url = git@github.com:UBCSailbot/global-pathfinding.git
+[submodule "projects/local-pathfinding"]
+	path = projects/local-pathfinding
+	url = git@github.com:UBCSailbot/local-pathfinding.git

--- a/jenkins/can_bbb_nuc_integration.jenkinsfile
+++ b/jenkins/can_bbb_nuc_integration.jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                             '''
                         }
 
-                        // compile bruces controller code.
+                        // compile bruces controller code & local-pathfinding.
                         // TODO: This is not handled by git/jenkins at all. Changes
                         // to this code will not appear here.
                         dir('/home/raye/catkin_ws') {


### PR DESCRIPTION
Local-pathfinding within the catkin workspace on the NUC is 
now a symlink to the local-pathfinding submodule.
This allows us to test the most recent version of
local-pathfinding.