### PR TITLE
Retrieve Data from actual CAN bus

### DIFF
--- a/jenkins/can_bbb_nuc_integration.jenkinsfile
+++ b/jenkins/can_bbb_nuc_integration.jenkinsfile
@@ -125,11 +125,8 @@ pipeline {
                             sh 'JENKINS_NODE_COOKIE=nokill nohup /usr/bin/socat -d -d pty,raw,echo=0,link=/tmp/serialport1 pty,raw,echo=0,link=/tmp/serialport2 &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/network_table_server > network_table_server.log &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_eth_listener 192.168.1.60 5555 > bbb_eth_listener.log &'
-                            sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_canbus_listener vcan0 > bbb_canbus_listener.log &'
+                            sh 'JENKINS_NODE_COOKIE=nokill nohup ./build/bin/bbb_canbus_listener can0 > bbb_canbus_listener.log &'
                             sh 'JENKINS_NODE_COOKIE=nokill nohup ./projects/virtual_iridium/python/Iridium9602.py --webhook_server_endpoint 10.0.0.1:8000 --http_server_port 8085 -d /tmp/serialport2 -m HTTP_POST > virtual_iridium.log &'
-
-                            // Run this here so that we have gps coordinates in the network table and global pathfinding will work properly
-                            sh 'JENKINS_NODE_COOKIE=nokill nohup ./scripts/mock_sensors.py -c vcan0 -f recorded_data/mock_can_data.csv --loop &'
                         }
                     }
                 }
@@ -203,7 +200,7 @@ pipeline {
                     }
                     steps {
                         dir("/home/debian/workspace/can_bbb_nuc_integration/") {
-                            sh './scripts/canbus_data_checker.py -c vcan0'
+                            sh './scripts/canbus_data_checker.py -c can0 > canbus_data_checker.log'
 							sh './build/bin/viewtree'
                         }
                     }
@@ -225,6 +222,8 @@ pipeline {
                             sh 'cat bbb_satellite_listener.log'
                             echo "======== BBB virtual_iridium ========"
                             sh 'cat virtual_iridium.log'
+                            echo "======== BBB canbus_data_checker ========"
+                            sh 'cat canbus_data_checker.log'
                         }
                     }
                 }
@@ -279,7 +278,6 @@ def force_cleanup() {
             sh 'pkill -f bbb_canbus_listener || true'
             sh 'pkill -f bbb_satellite_listener || true'
             sh 'pkill -f Iridium9602 || true'
-            sh 'pkill -f mock_sensors || true'
             sh 'pkill -f socat || true'
             sh 'rm -r /tmp/sailbot/ || true'
         }
@@ -311,7 +309,6 @@ def cleanup() {
             sh 'pkill -f bbb_canbus_listener || echo "error: failed to kill bbb_canbus_listener"'
             sh 'pkill -f bbb_satellite_listener || echo "error: failed to kill bbb_satellite_listener"'
             sh 'pkill -f Iridium9602 || echo "error: failed to kill Iridium9602"'
-            sh 'pkill -f mock_sensors || echo "error: failed to kill mock_sensor"'
             sh 'pkill -f socat || echo "error: failed to kill socat"'
             sh 'rm -r /tmp/sailbot/'
         }

--- a/projects/bbb_canbus_listener/main.cpp
+++ b/projects/bbb_canbus_listener/main.cpp
@@ -68,7 +68,7 @@ void MotorCallback(NetworkTable::Node node, \
     frame.data[1] = angle_array[1];
     frame.data[2] = angle_array[2];
     frame.data[3] = angle_array[3];
-    std::cout << "Sending angle:" << angle << std::endl;
+    // std::cout << "Sending angle:" << angle << std::endl;
     if (write(s, &frame, sizeof(struct can_frame)) != sizeof(struct can_frame)) {
         perror("Write");
         return;
@@ -131,6 +131,7 @@ int main(int argc, char **argv) {
         std::cout << "Can ID = " << std::hex << frame.can_id << std::endl << std::dec;
         switch (frame.can_id) {
             case WIND_SENS0_FRAME_ID : {
+                std::cout << "Received Wind Sensor 0 Frame" << std::endl;
                 int angle = GET_WIND_ANGLE(frame.data);
                 int speed = GET_WIND_SPEED(frame.data);
 
@@ -138,18 +139,21 @@ int main(int argc, char **argv) {
                 break;
             }
             case WIND_SENS1_FRAME_ID : {
+                std::cout << "Received Wind Sensor 1 Frame" << std::endl;
                 int angle = GET_WIND_ANGLE(frame.data);
                 int speed = GET_WIND_SPEED(frame.data);
                 SetWindSensorData(angle, speed, "1");
                 break;
             }
             case WIND_SENS2_FRAME_ID : {
+                std::cout << "Received Wind Sensor 2 Frame" << std::endl;
                 int angle = GET_WIND_ANGLE(frame.data);
                 int speed = GET_WIND_SPEED(frame.data);
                 SetWindSensorData(angle, speed, "2");
                 break;
             }
             case SAILENCODER_FRAME_ID : {
+                std::cout << "Received Sailencoder Frame" << std::endl;
                 std::map<std::string, NetworkTable::Value> values;
                 NetworkTable::Value boom_angle;
                 int angle = GET_SAILENCODER_ANGLE(frame.data);
@@ -331,7 +335,7 @@ int main(int argc, char **argv) {
                 break;
             }
             case BMS_FRAME_ID_1: {
-                std::cout << "bms 1:" << std::endl;
+                std::cout << "Received BMS1 Frame:" << std::endl;
 
                 std::map<std::string, NetworkTable::Value> values;
                 NetworkTable::Value bms_volt_data;
@@ -376,6 +380,7 @@ int main(int argc, char **argv) {
                 break;
             }
             case ACCEL_FRAME_ID: {
+                std::cout << "Received Accel Frame:" << std::endl;
                 NetworkTable::Value accel_x_pos;
                 std::map<std::string, NetworkTable::Value> values;
                 int16_t x_pos = GET_ACCEL_X_DATA(frame.data);


### PR DESCRIPTION
Jenkins will now retrieve data from the actual CAN bus
rather than virtual can. The data being fed into the 
CAN bus is still mock data that Simon has curated. 

Note: There still seems to be bugs with the conversion
of the received CAN data, as well as discrepancies between
our network table nodes and the data being transmitted through 
CAN. This pr is just so tests going forward are listening to the 
actual CAN bus. 