### PR TITLE
NAV-201 Decode Waypoint Data from Rockblock

### DIFF
--- a/projects/bbb_satellite_listener/main.cpp
+++ b/projects/bbb_satellite_listener/main.cpp
@@ -10,8 +10,6 @@
 #include <boost/algorithm/string.hpp>
 #include <mutex>
 #include <stdexcept>
-#include <vector>
-#include <sstream>
 #include <cstdio>
 
 #include "Connection.h"

--- a/src/Uri.h
+++ b/src/Uri.h
@@ -81,6 +81,8 @@
 #define WINCH_MAIN_ANGLE "/actuation_angle/winch/winch_main/angle"
 #define WINCH_JIB_ANGLE "/actuation_angle/winch/winch_jib/angle"
 
+#define WAYPOINTS_GP "waypoints"
+
 //TODO: Add UCCM Uris
 
 #endif  // URI_H_


### PR DESCRIPTION
Data sent to the Iridium server has to be in hex.
The rockblock then relays the received hex data as a string. 
However the relayed string is the ascii translation, when in reality our google protobuf object is a byte stream stored in a string container. 
This PR converts the received string back to a hex value then to a byte stream then back to a string that can be decoded by our protobuf functions. 
Note: this does not include the ring alert feature