### PR TITLE
NAV-233 Send Multiple Waypoints via Satellite

### DIFF
--- a/scripts/mock_waypoint_data.py
+++ b/scripts/mock_waypoint_data.py
@@ -24,6 +24,15 @@ def main():
         gpsCoord = value.waypoints.add()
         gpsCoord.latitude = x
         gpsCoord.longitude = x
+        gpsCoord = value.waypoints.add()
+        gpsCoord.latitude = x
+        gpsCoord.longitude = x
+        gpsCoord = value.waypoints.add()
+        gpsCoord.latitude = x
+        gpsCoord.longitude = x
+        gpsCoord = value.waypoints.add()
+        gpsCoord.latitude = x
+        gpsCoord.longitude = x
 
         uri = "waypoints"
         print(value)

--- a/src/NonProtoConnection.cpp
+++ b/src/NonProtoConnection.cpp
@@ -124,8 +124,8 @@ std::list<std::pair<double, double>> NetworkTable::NonProtoConnection::GetCurren
 }
 
 std::pair<double, double> NetworkTable::NonProtoConnection::GetCurrentGpsCoords() {
-    const std::string lat_uri = "gps/gprmc/latitude";
-    const std::string lon_uri = "gps/gprmc/longitude";
+    const std::string lat_uri = "gps_can/gprmc/latitude";
+    const std::string lon_uri = "gps_can/gprmc/longitude";
 
     double lat, lon;
     std::pair<double, double> curr_gps;

--- a/src/Uri.h
+++ b/src/Uri.h
@@ -14,13 +14,15 @@
 #define WIND3_SPEED "/wind_sensor_3/iimwv/wind_speed"
 #define WIND3_ANGLE "/wind_sensor_3/iimwv/wind_angle"
 
-#define GPS_CAN_TIME "/gps_can/gprmc/utc_timestamp"
+// Dependency within global-pathfinding - Do NOT change 
 #define GPS_CAN_LAT "/gps_can/gprmc/latitude"
 #define GPS_CAN_LON "/gps_can/gprmc/longitude"
+
 #define GPS_CAN_GNDSPEED "/gps_can/gprmc/ground_speed"
 #define GPS_CAN_TMG "/gps_can/gprmc/track_made_good"
 #define GPS_CAN_TRUE_HEADING "/gps_can/gprmc/true_heading"
 #define GPS_CAN_MAGVAR "/gps_can/gprmc/magnetic_variation"
+#define GPS_CAN_TIME "/gps_can/gprmc/utc_timestamp"
 
 #define GPS_CAN_VALID "/gps_can/gprmc/valid"
 #define GPS_CAN_VARWEST "/gps_can/gprmc/var_west"
@@ -81,6 +83,7 @@
 #define WINCH_MAIN_ANGLE "/actuation_angle/winch/winch_main/angle"
 #define WINCH_JIB_ANGLE "/actuation_angle/winch/winch_jib/angle"
 
+// Dependency within global-pathfinding - Do NOT change 
 #define WAYPOINTS_GP "waypoints"
 
 //TODO: Add UCCM Uris


### PR DESCRIPTION
Can successfully send & receive multiple sets of waypoints via satellite.
Security parameters are _temporarily?_ set as optional parameters instead of permanent to prevent using credits in Jenkins builds.
Note - Initially we thought max amount of data permitted to be sent was 240bytes.
Based on testing, seems like max is only 126, meaning only 5 waypoints can be sent per POST request to the Iridium server.
The 126bytes use up 3 credits. 