### PR TITLE
Merging startup and terminate scripts into /scripts directory

### DIFF
--- a/scripts/startup/bbb_startup.sh
+++ b/scripts/startup/bbb_startup.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Steps for BBB
+# 1) Run network_table_server
+# 2) Run bbb_canbus_listener
+# 3) Run bbb_satellite_listener
+# 4) Run bbb_ais_listener
+# 5) Run light-client to populate with mock data
+
+NT_ROOT="/home/debian/network-table"
+
+# Command arguments
+CAN_ARG1="can0"
+
+SAT_ARG1="60"
+SAT_ARG2="360"
+SAT_ARG3="600"
+SAT_TTY="/dev/ttyS2"
+
+ETH_IP="192.168.1.60"
+ETH_PORT="5555"
+
+NT_CMD="./build/bin/network_table_server &"
+CAN_CMD="./build/bin/bbb_canbus_listener $CAN_ARG1 &"
+SAT_CMD="./build/bin/bbb_satellite_listener $SAT_ARG1 $SAT_ARG2 $SAT_ARG3 $SAT_TTY &"
+AIS_CMD="./build/bin/bbb_ais_listener &"
+ETH_CMD="./build/bin/bbb_eth_listener $ETH_IP $ETH_PORT &"
+LC_CMD="./build/bin/light_client &"
+
+printf "\nStartup script for BBB\n"
+printf "\n================================\n"
+
+########################
+# network_table_server
+########################
+printf "Network Table Server\n"
+printf ".....................\n"
+
+if pgrep -f "network_table_server" > /dev/null;
+then
+    NT_PID=$(pgrep -f "network_table_server")
+    printf "Network-table server already running with PID: %d\n" $NT_PID
+else
+    printf "Server not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$NT_CMD" > /dev/null
+    NT_PID=$(pgrep -f "network_table_server")
+    
+    printf "Started nt_server with PID: %d\n" $NT_PID
+fi
+printf "\n================================\n"
+
+########################
+# bbb_canbus_listener
+########################
+printf "BBB CANbus Listener\n"
+printf "\n================================\n"
+
+if pgrep -f "bbb_canbus_listener" > /dev/null;
+then
+    BC_PID=$(pgrep -f "bbb_canbus_listener")
+    printf "BBB Canbus listener already running with PID: %d\n" $BC_PID
+else
+    printf "BBB Canbus not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$CAN_CMD"
+    BC_PID=$(pgrep -f "bbb_canbus_listener")
+
+    printf "Started bbb_canbus_listener with PID: %d\n" $BC_PID
+fi
+
+########################
+# bbb_satellite_listener
+########################
+printf "BBB Satellite Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_satellite_listener" > /dev/null;
+then
+    BS_PID=$(pgrep -f "bbb_satellite_listener")
+    printf "BBB Satellite Listener already running with PID: %d\n" $BS_PID
+else
+    printf "BBB Satellite Listener not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$SAT_CMD"
+    BS_PID=$(pgrep -f "bbb_satellite_listener")
+    
+    printf "Started bbb_satellite_listener with PID: %d\n" $BS_PID
+fi
+printf "\n================================\n"
+
+########################
+# bbb_ais_listener
+########################
+printf "BBB AIS Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_ais_listener" > /dev/null;
+then
+    BA_PID=$(pgrep -f "bbb_ais_listener")
+    printf "BBB AIS Listener already running with PID: %d\n" $BA_PID
+else
+    printf "BBB AIS Listener not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$AIS_CMD"
+    BA_PID=$(pgrep -f "bbb_ais_listener")
+    
+    printf "Started bbb_ais_listener with PID: %d\n" $BA_PID
+fi
+printf "\n================================\n"
+
+########################
+# bbb_eth_listener
+########################
+printf "BBB ETH Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_eth_listener" > /dev/null;
+then
+    BE_PID=$(pgrep -f "bbb_eth_listener")
+    printf "BBB ETH Listener already running with PID: %d\n" $BE_PID
+else
+    printf "BBB ETH Listener not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$ETH_CMD" > /dev/null
+    BE_PID=$(pgrep -f "bbb_eth_listener")
+    
+    printf "Started bbb_eth_listener with PID: %d\n" $BE_PID
+fi
+printf "\n================================\n"
+
+########################
+# light_client
+########################
+printf "Light client\n"
+printf ".....................\n"
+
+# Ask user if light client should be run
+read -p "Do you want to run light client? [y/n]" -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then 
+    if pgrep -f "light_client" > /dev/null;
+    then
+        LC_PID=$(pgrep -f "light_client")
+        printf "Light client already running with PID: %d\n" $LC_PID
+    else
+        printf "Light client not started. Starting new process\n"
+    
+        cd $NT_ROOT
+        eval "$LC_CMD" > /dev/null
+        LC_PID=$(pgrep -f "light_client")
+    
+        printf "Started light_client with PID: %d\n" $LC_PID
+    fi
+else
+    printf "Not running light client\n"
+fi
+
+printf "\n================================\n"
+printf "Startup script for BBB complete\n"
+printf "Network-table Server PID: %d\n" $NT_PID
+printf "BBB Canbus Listener PID: %d\n" $BC_PID
+printf "BBB Satellite Listener PID: %d\n" $BS_PID
+printf "BBB AIS Listener PID: %d\n" $BA_PID
+printf "BBB ETH Listener: %d\n" $BE_PID
+printf "Light client: %d\n" $LC_PID

--- a/scripts/startup/helpers/local_pathfinding_startup.sh
+++ b/scripts/startup/helpers/local_pathfinding_startup.sh
@@ -1,0 +1,4 @@
+ #!/bin/bash
+
+roslaunch local_pathfinding main_loop_and_interface.launch wandb:=true land_mass_file:=land_masses/vancouver_depth_5m_10_11_2021-10_28_14.csv
+

--- a/scripts/startup/helpers/mock_ais_startup.sh
+++ b/scripts/startup/helpers/mock_ais_startup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rosrun local_pathfinding MOCK_AIS.py

--- a/scripts/startup/helpers/mock_sensors_startup.sh
+++ b/scripts/startup/helpers/mock_sensors_startup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rosrun local_pathfinding MOCK_sensors.py

--- a/scripts/startup/land_startup.sh
+++ b/scripts/startup/land_startup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Steps for landserver:
+# 1) Run network_table_server (./build/bin/network_table_server) 
+# 2) Run land-satellite-listener (command too long to paste)
+# 3) Run global pathfinding
+#    (./build/bin/pathfinder_cli -p 8 --navigate 48 235 21 203)
+
+NT_ROOT="/root/network-table"
+# pgrep search commands (not full commands since pgrep can use regex)
+NT_PGREP="network_table_server"
+LS_PGREP="python3 land_satellite_listener.py"
+GP_PGREP="pathfinder_cli"
+
+#Arguments for land-satellite-listener
+LS_PORT="-p 8000"
+LS_URL="-e https://rockblock.rock7.com/rockblock/MT"
+LS_FREQ_UNIT="-f 10 -u SEC"
+LS_B="-b 70.36.55.243"
+LS_USER="-n captain@ubcsailbot.org"
+LS_PASS="-w raye2020"
+LS_ID="-r 300234068129370"
+LS_IPSRC="-i 212.71.235.32"
+
+NT_CMD="./build/bin/network_table_server &"
+LS_CMD="python3 land_satellite_listener.py $LS_PORT $LS_URL $LS_FREQ_UNIT $LS_UNIT $LS_B $LS_USER $LS_PASS $LS_ID $LS_IPSRC &"
+GP_CMD="./projects/global-pathfinding/build/bin/pathfinder_cli -p 8 --navigate 48 235 21 203"
+
+printf "\nStartup script for land server\n"
+printf "\n================================\n"
+
+# network_table_server
+printf "Network Table Server\n"
+printf ".....................\n"
+
+if pgrep -f "$NT_PGREP" > /dev/null;
+then
+    NT_PID=$(pgrep -f "$NT_PGREP")
+    printf "Network-table server already running with PID: %d\n" $NT_PID
+else
+    printf "Server not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$NT_CMD"
+    NT_PID=$(pgrep -f "$NT_PGREP")
+    
+    printf "Started nt_server with PID: %d\n" $NT_PID
+fi
+printf "\n================================\n"
+
+# land_satellite_listener
+printf "Land Satellite Listener\n"
+printf ".....................\n"
+
+if pgrep -f "land_satellite_listener" > /dev/null;
+then
+    LS_PID=$(pgrep -f "$LS_PGREP")
+    printf "Satellite listener already running with PID: %d\n" $LS_PID
+else
+    printf "Listener not started. Starting new process\n"
+    
+    cd $NT_ROOT/projects/land_satellite_listener
+    eval "$LS_CMD"
+    LS_PID=$(pgrep -f "$LS_PGREP")
+
+    printf "Started land satellite listener with PID: %d\n" $LS_PID
+fi
+printf "\n================================\n"
+
+# global pathfinding
+printf "Global Pathfinding\n"
+printf ".....................\n"
+
+if pgrep -f "$GP_PGREP" > /dev/null;
+then
+    GP_PID=$(pgrep -f "$GP_PGREP")
+    printf "Global pathfinding already running with PID: %d\n" $GP_PID
+else
+    printf "Global pathfinding not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$GP_CMD"
+    GP_PID=$(pgrep -f "$GP_PGREP")
+
+    printf "Started global pathfinding with PID: %d\n", $GP_PID
+fi
+printf "\n================================\n\n"
+
+printf "Startup script complete\n"
+printf "Network-table Server PID: %d\n" $NT_PID
+printf "Land Satellite Listener PID: %d\n" $LS_PID
+printf "Global Pathfinding PID: %d\n" $GP_PID

--- a/scripts/startup/nuc_startup.sh
+++ b/scripts/startup/nuc_startup.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Steps for NUC
+# 1) Start roscore
+# 2) Run nuc-eth-listener
+# 3) Run local pathfinding
+# 4) Run mocks scripts (MOCK_AIS ; MOCK_sensors)
+# No need to start visualizer automatically
+
+NT_ROOT="/home/raye/network-table"
+
+# nuc-eth-listener arguments
+NE_IP="192.168.1.60"
+NE_PORT="5555"
+
+NE_CMD="./build/bin/nuc_eth_listener $NE_IP $NE_PORT &"
+
+HELPER_PATH="/home/raye/network-table/scripts/startup/helpers"
+LP_PATH="$HELPER_PATH/local_pathfinding_startup.sh"
+MOCK_AIS_PATH="$HELPER_PATH/mock_ais_startup.sh"
+MOCK_SENSORS_PATH="$HELPER_PATH/mock_sensors_startup.sh"
+
+# Assuming melodica is sourced properly
+
+printf "\nStartup script for NUC\n"
+printf "\n================================\n"
+
+# Roscore
+#printf "Roscore\n"
+#printf ".....................\n"
+
+#if pgrep -f "roscore" > /dev/null;
+#then
+    #ROS_PID=$(pgrep -f "roscore")
+    #printf "Roscore already running with PID: %d\n"$ROS_PID
+#else
+    #printf "Roscore not started. Starting roscore\n"
+
+    #roscore &
+    #ROS_PID=$(pgrep -f "roscore")
+
+    #printf "Started roscore with PID: %d\n" $ROS_PID
+#fi
+#printf "\n================================\n"
+
+# nuc-eth-listener
+printf "NUC ETH Listener\n"
+printf ".....................\n"
+
+if pgrep -f "nuc_eth_listener" > /dev/null;
+then
+    NE_PID=$(pgrep -f "nuc_eth_listener")
+    printf "NUC ETH listener already running with PID: %d\n" $NE_PID
+else
+    printf "NUC ETH listener not started. Starting new process\n"
+
+    cd $NT_ROOT
+    eval "$NE_CMD"
+    NE_PID=$(pgrep -f "nuc_eth_listener")
+
+    printf "NUC ETH listener started with PID: %d\n" $NE_PID
+fi
+printf "\n================================\n"
+
+# local pathfinding
+printf "Local Pathfinding\n"
+printf ".....................\n"
+
+if pgrep -f "local_pathfinding" > /dev/null;
+then
+  LP_PID=$(pgrep -f "local_pathfinding")
+  printf "Local pathfinding already running with PID: %d\n" $LP_PID
+else
+  printf "Local pathfinding not started. Starting new process\n"
+
+  screen -dmS local_pathfinding $LP_PATH
+  LP_PID=$(pgrep -f "local_pathfinding")
+
+  printf "Local pathfinding started with PID: %d\n" $LP_PID
+fi
+printf "\n================================\n"
+
+# Mock scripts
+printf "Mock Scripts (AIS ; Sensors)\n"
+printf ".....................\n"
+# Ask user if both mock scripts should be run
+read -p "Do you want to run MOCK_AIS.py? [y/n]" -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then 
+    if pgrep -f "MOCK_AIS.py" > /dev/null;
+    then
+        MA_PID=$(pgrep -f "MOCK_AIS.py")
+        printf "MOCK_AIS.py already running with PID: %d\n" $MA_PID
+    else
+        printf "MOCK_AIS.py not runnin. Starting process\n"
+
+        screen -dmS mock_ais $MOCK_AIS_PATH
+        MA_PID=$(pgrep -f "MOCK_AIS.py")
+
+        printf "MOCK_AIS.py started with PID: %d\n" $MA_PID
+    fi
+else
+    printf "Not running MOCK_AIS.py\n"
+fi
+
+read -p "Do you want to run MOCK_sensors.py? [y/n]" -r 
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    if pgrep -f "MOCK_sensors.py" > /dev/null;
+    then
+        MS_PID=$(pgrep -f "MOCK_sensors.py")
+        printf "MOCK_sensors.py already running with PID: %d\n" $MS_PID
+    else
+        printf "MOCK_sensors.py not running. Starting process\n"
+
+        screen -dmS mock_sensors $MOCK_SENSORS_PATH
+        MS_PID=$(pgrep -f "MOCK_sensors.py")
+
+        printf "MOCK_sensors.py started with PID: %d\n" $MS_PID
+    fi
+else
+    printf "Not running MOCK_sensors.py\n"
+fi
+
+printf "\n================================\n"
+
+printf "NUC Startup script complete\n"

--- a/scripts/terminate/bbb_terminate.sh
+++ b/scripts/terminate/bbb_terminate.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Processes to terminate on BBB in no order:
+# bbb_canbus_listener
+# bbb_satellite_listener
+# bbb_ais_listener
+# bbb_eth_listener
+# network_table_server last (just in case)
+
+printf "\nScript to terminate processes for BBB\n"
+printf "\n================================\n"
+
+
+# bbb_canbus_listener
+printf "BBB Canbus Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_canbus_listener" > /dev/null;
+then
+    BC_PID=$(pgrep -f "bbb_canbus_listener")
+    kill -9 $BC_PID
+    printf "Terminated bbb_canbus_listener with PID: %d\n" $BC_PID
+else
+    printf "PGREP couldn't find running bbb_canbus_listener\n"
+fi
+printf "\n================================\n"
+
+# bbb_satellite_listener
+printf "BBB Satellite Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_satellite_listener" > /dev/null;
+then
+    BS_PID=$(pgrep -f "bbb_satellite_listener")
+    kill -9 $BS_PID
+    printf "Terminated bbb_satellite_listener with PID: %d\n" $BS_PID
+else
+    printf "PGREP couldn't find running bbb_satellite_listener\n"
+fi
+printf "\n================================\n"
+
+# bbb_ais_listener
+printf "BBB AIS Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_ais_listener" > /dev/null;
+then
+    BA_PID=$(pgrep -f "bbb_ais_listener")
+    kill -9 $BA_PID
+    printf "Terminated bbb_ais_listener with PID: %d\n" $BA_PID
+else
+    printf "PGREP couldn't find running bbb_ais_listener\n"
+fi
+printf "\n================================\n"
+
+# bbb_eth_listener
+printf "BBB ETH Listener\n"
+printf ".....................\n"
+
+if pgrep -f "bbb_eth_listener" > /dev/null;
+then
+    BE_PID=$(pgrep -f "bbb_eth_listener")
+    kill -9 $BE_PID
+    printf "Terminated bbb_eth_listener with PID: %d\n" $BE_PID
+else
+    printf "PGREP couldn't find running bbb_eth_listener\n"
+fi
+printf "\n================================\n"
+
+# network_table_server
+printf "Network Table Server"
+printf ".....................\n"
+
+if pgrep -f "network_table_server" > /dev/null;
+then
+    NT_PID=$(pgrep -f "network_table_server")
+    kill -9 $NT_PID
+    printf "Terminated network_table_server with PID: %d\n" $NT_PID
+else
+    printf "PGREP couldn't find running network_table_server\n"
+fi
+printf "\n================================\n\n"
+
+printf "Terminate script completed\n"

--- a/scripts/terminate/land_terminate.sh
+++ b/scripts/terminate/land_terminate.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Processes to terminate for landserver in no order:
+# land_satellite_listener
+# pathfinder_cli
+# network_table_server
+
+printf "\nScript to terminate processes for land server\n"
+printf "\n================================\n"
+
+
+# land_satellite_listener
+printf "Land Satellite Listener\n"
+printf ".....................\n"
+
+if pgrep -f "python3 land_satellite_listener.py" > /dev/null;
+then
+    LS_PID=$(pgrep -f "python3 land_satellite_listener.py")
+    kill -9 $LS_PID
+    printf "Terminated land_satellite_listener with PID: %d\n" $LS_PID
+else
+    printf "PGREP couldn't find running land_satellite_listener\n"
+fi
+printf "\n================================\n"
+
+# pathfinder_cli
+printf "Global Pathfinding\n"
+printf ".....................\n"
+
+if pgrep -f "./build/bin/pathfinder_cli" > /dev/null;
+then
+    PF_PID=$(pgrep -f "./build/bin/pathfinder_cli")
+    kill -9 $PF_PID
+    printf "Terminated global pathfinding with PID: %d\n" $PF_PID
+else
+    printf "PGREP couldn't find running Global pathfinding\n"
+fi
+printf "\n================================\n"
+
+# network_table_server
+printf "Network-table Server\n"
+printf ".....................\n"
+
+if pgrep -f "./build/bin/network_table_server" > /dev/null;
+then
+    NT_PID=$(pgrep -f "./build/bin/network_table_server")
+    kill -9 $NT_PID
+    printf "Terminated nt-server with PID: %d\n" $NT_PID
+else
+    printf "PGREP couldn't find running nt-server\n"
+fi
+printf "\n================================\n"
+
+printf "Terminate script complete\n"

--- a/scripts/terminate/nuc_terminate.sh
+++ b/scripts/terminate/nuc_terminate.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Processes to terminate on NUC in no order:
+# roscore
+# nuc_eth_listener
+# local pathfinding
+
+printf "\nScript to terminate processes for NUC\n"
+printf "\n================================\n"
+
+# roscore
+# Ask user if roscore should be shut down
+#printf "Roscore\n"
+#printf ".....................\n"
+
+#read -p "Do you want to terminate roscore? " -r
+#echo
+#if [[ $REPLY =~ ^[Yy]$ ]]
+#then
+    #if pgrep -f "roscore" > /dev/null;
+    #then
+        #RC_PID=$(pgrep -f "roscore")
+        #kill -9 $RC_PID
+        #printf "Terminated roscore with PID: %d\n" $RC_PID
+    #else
+        #printf "PGREP couldn't find roscore running\n"
+    #fi
+#else
+    #printf "NOT shutting down roscore\n"
+#fi
+#printf "\n================================\n"
+
+# nuc_eth_listener
+printf "NUC ETH Listener\n"
+printf ".....................\n"
+
+if pgrep -f "nuc_eth_listener" > /dev/null;
+then
+    NE_PID=$(pgrep -f "nuc_eth_listener")
+    kill -9 $NE_PID
+    printf "Terminated nuc_eth_listener with PID: %d\n" $NE_PID
+else
+    printf "PGREP couldn't find nuc_eth_listener running\n"
+fi
+printf "\n================================\n"
+
+# local pathfinding
+printf "Local pathfinding\n"
+printf ".....................\n"
+
+if pgrep -f "local_pathfinding" > /dev/null;
+then
+    LP_PID=$(pgrep -f "local_pathfinding")
+    kill -9 $LP_PID
+    printf "Terminated local_pathfinding with PID: %d\n" $LP_PID
+else
+    printf "PGREP couldn't find local_pathfinding running\n"
+fi
+if pgrep -f "local-pathfinding" > /dev/null;
+then
+    LP_PID=$(pgrep -f "local-pathfinding")
+    kill -9 $LP_PID
+    printf "Terminated local-pathfinding with PID: %d\n" $LP_PID
+else
+    printf "PGREP couldn't find local-pathfinding running\n"
+fi
+
+# mock_ais.py
+printf "ROS Mock Scripts\n"
+printf ".....................\n"
+
+if pgrep -f "MOCK_AIS.py" > /dev/null;
+then
+    MA_PID=$(pgrep -f "MOCK_AIS.py")
+    kill -9 $MA_PID
+    printf "Terminated MOCK_AIS.py with PID: %d\n" $MA_PID
+else
+    printf "PGREP couldn't find MOCK_AIS.py running\n"
+fi
+# mock_sensors.py
+if pgrep -f "MOCK_sensors.py" > /dev/null;
+then
+    MS_PID=$(pgrep -f "MOCK_sensors.py")
+    kill -9 $MS_PID
+    printf "Terminated MOCK_sensors.py with PID: %d\n" $MS_PID
+else
+    printf "PGREP couldn't find MOCK_sensors.py running\n"
+fi


### PR DESCRIPTION
Added startup and terminate scripts for processes listed in "Full System Integration" page.
Startup scripts located in network-table/scripts/startup
Terminate scripts located in network-table/scripts/terminate

- Startup scripts checks if process is already running before starting a new process.
- Terminate scripts attempts to find the PID of the process and terminates if PID exists; nothing otherwise.
- For MOCK_AIS.py and MOCK_sensors.py startup in nuc_startup.sh, prompts user to start or skip these scripts.
- For roscore terminate in nuc_terminate.sh, prompts user to terminate or skip roscore.