### PR TITLE
Added logic for handling stale GPS CAN

### DIFF
--- a/projects/bbb_ais_listener/main.cpp
+++ b/projects/bbb_ais_listener/main.cpp
@@ -132,21 +132,37 @@ int main(int argc, char** argv) {
                 // Creates and configures NetworkTable values for insertion
                 NetworkTable::Value ais_gps_latitude;
                 NetworkTable::Value ais_gps_longitude;
+                NetworkTable::Value ais_gps_speed_knots;
+                NetworkTable::Value ais_gps_true_heading;
 
                 double raye_latitude = b.m_latitude;
                 double raye_longitude = b.m_longitude;
+                double raye_speed = b.m_sog;
+                int raye_true_heading = b.m_trueHeading;
 
                 ais_gps_latitude.set_type(NetworkTable::Value::FLOAT);
                 ais_gps_longitude.set_type(NetworkTable::Value::FLOAT);
+                ais_gps_speed_knots.set_type(NetworkTable::Value::FLOAT);
+                ais_gps_true_heading.set_type(NetworkTable::Value::INT);
 
                 ais_gps_latitude.set_float_data(static_cast<float>(raye_latitude));
                 ais_gps_longitude.set_float_data(static_cast<float>(raye_longitude));
+                ais_gps_speed_knots.set_float_data(static_cast<float>(raye_speed));
+                ais_gps_true_heading.set_int_data(static_cast<int>(raye_true_heading));
 
                 // Formats the Networktable::Value in the values map
                 values.insert(std::pair<std::string, NetworkTable::Value>\
                         (GPS_AIS_LAT, ais_gps_latitude));
                 values.insert(std::pair<std::string, NetworkTable::Value>\
                         (GPS_AIS_LON, ais_gps_longitude));
+                if (b.m_sogValid) {
+                    values.insert(std::pair<std::string, NetworkTable::Value>\
+                        (GPS_AIS_GNDSPEED, ais_gps_speed_knots));
+                }
+                if (b.m_trueHeadingValid) {
+                    values.insert(std::pair<std::string, NetworkTable::Value>\
+                        (GPS_AIS_TRUE_HEADING, ais_gps_true_heading));
+                }
 
                 // Sets the AIS_GPS values
                 try {

--- a/projects/nuc_eth_listener/main.cpp
+++ b/projects/nuc_eth_listener/main.cpp
@@ -1,5 +1,8 @@
 // Copyright 2017 UBC Sailbot
 
+#include <cmath>
+#include <ctime>
+#include <string>
 #include <zmq.hpp>
 #include <thread>
 #include <iostream>
@@ -140,6 +143,31 @@ void PowerControllerCallBack(const sailbot_msg::power_controller ros_power_data)
 }
 */
 
+static inline bool lat_lon_float_equal(float a, float b) {
+    static constexpr float epsilon = 0.0001;
+    return (std::fabs(a) - std::fabs(b)) < epsilon;
+}
+
+static inline bool lat_lon_equal(std::array<float, 2> lat_lon_a, std::array<float, 2> lat_lon_b) {
+    return lat_lon_float_equal(lat_lon_a[0], lat_lon_b[0]) && lat_lon_float_equal(lat_lon_a[1], lat_lon_b[1]);
+}
+
+static bool IsGpsCanStale(std::array<float, 2> gps_can_lat_lon, std::array<float, 2> gps_ais_lat_lon) {
+    static constexpr int stale_time_sec = 1200;  // 20 min
+    static int prev_non_stale_time = std::time(nullptr);
+    static std::array<float, 2> prev_can_lat_lon_arr = {0.0, 0.0};
+    if (!lat_lon_equal(gps_can_lat_lon, gps_ais_lat_lon)) {
+        if (lat_lon_equal(gps_can_lat_lon, prev_can_lat_lon_arr)
+            && ((std::time(nullptr) - prev_non_stale_time) > stale_time_sec)) {
+            std::cout << "GPS CAN is stale" << std::endl;
+            return true;
+        }
+    } else {
+        prev_non_stale_time = std::time(nullptr);
+    }
+    return false;
+}
+
 void PublishSensorData() {
     while (true) {
         /*
@@ -201,20 +229,33 @@ void PublishSensorData() {
             sensors.wind_sensor_3_angle_degrees = proto_sensors.wind_sensor_3().iimwv().wind_angle();
 
             // GPS
+            // GPS AIS only has the lat and lon fields so replicate everything else
+            sensors.gps_ais_latitude_degrees = proto_sensors.gps_ais().gprmc().latitude();
+            sensors.gps_ais_longitude_degrees = proto_sensors.gps_ais().gprmc().longitude();
+            sensors.gps_ais_timestamp_utc = proto_sensors.gps_can().gprmc().utc_timestamp();
+            sensors.gps_ais_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
+            sensors.gps_ais_track_made_good_degrees = proto_sensors.gps_can().gprmc().track_made_good();
+            sensors.gps_ais_magnetic_variation_degrees = proto_sensors.gps_can().gprmc().magnetic_variation();
+
             sensors.gps_can_timestamp_utc = proto_sensors.gps_can().gprmc().utc_timestamp();
-            sensors.gps_can_latitude_degrees = proto_sensors.gps_can().gprmc().latitude();
-            sensors.gps_can_longitude_degrees = proto_sensors.gps_can().gprmc().longitude();
             sensors.gps_can_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
             sensors.gps_can_track_made_good_degrees = proto_sensors.gps_can().gprmc().track_made_good();
             sensors.gps_can_magnetic_variation_degrees = proto_sensors.gps_can().gprmc().magnetic_variation();
             sensors.gps_can_true_heading_degrees = proto_sensors.gps_can().gprmc().true_heading();
 
-            sensors.gps_ais_timestamp_utc = proto_sensors.gps_can().gprmc().utc_timestamp();
-            sensors.gps_ais_latitude_degrees = proto_sensors.gps_can().gprmc().latitude();
-            sensors.gps_ais_longitude_degrees = proto_sensors.gps_can().gprmc().longitude();
-            sensors.gps_ais_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
-            sensors.gps_ais_track_made_good_degrees = proto_sensors.gps_can().gprmc().track_made_good();
-            sensors.gps_ais_magnetic_variation_degrees = proto_sensors.gps_can().gprmc().magnetic_variation();
+            std::array<float, 2> gps_can_lat_lon =
+                {proto_sensors.gps_can().gprmc().latitude(), proto_sensors.gps_can().gprmc().longitude()};
+            std::array<float, 2> gps_ais_lat_lon =
+                {sensors.gps_ais_latitude_degrees, sensors.gps_ais_longitude_degrees};
+
+            // If GPS CAN is stale then use AIS lat lon
+            if (IsGpsCanStale(gps_can_lat_lon, gps_ais_lat_lon)) {
+                sensors.gps_can_latitude_degrees = gps_can_lat_lon[0];
+                sensors.gps_can_longitude_degrees = gps_can_lat_lon[1];
+            } else {
+                sensors.gps_can_latitude_degrees = gps_ais_lat_lon[0];
+                sensors.gps_can_longitude_degrees = gps_ais_lat_lon[1];
+            }
 
             // Accelerometer
             sensors.accelerometer_x_force_millig = \

--- a/projects/nuc_eth_listener/main.cpp
+++ b/projects/nuc_eth_listener/main.cpp
@@ -232,16 +232,18 @@ void PublishSensorData() {
             // GPS AIS only has the lat and lon fields so replicate everything else
             sensors.gps_ais_latitude_degrees = proto_sensors.gps_ais().gprmc().latitude();
             sensors.gps_ais_longitude_degrees = proto_sensors.gps_ais().gprmc().longitude();
+            sensors.gps_ais_true_heading_degrees = proto_sensors.gps_ais().gprmc().true_heading();
+            sensors.gps_ais_groundspeed_knots = proto_sensors.gps_ais().gprmc().ground_speed();
+            // A comment in bbb_ais_listener/main.cpp says not to use utc timestamp for GPS AIS
             sensors.gps_ais_timestamp_utc = proto_sensors.gps_can().gprmc().utc_timestamp();
-            sensors.gps_ais_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
+            // Does not exist for GPS AIS
             sensors.gps_ais_track_made_good_degrees = proto_sensors.gps_can().gprmc().track_made_good();
+            // Does not exist for GPS AIS
             sensors.gps_ais_magnetic_variation_degrees = proto_sensors.gps_can().gprmc().magnetic_variation();
 
             sensors.gps_can_timestamp_utc = proto_sensors.gps_can().gprmc().utc_timestamp();
-            sensors.gps_can_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
             sensors.gps_can_track_made_good_degrees = proto_sensors.gps_can().gprmc().track_made_good();
             sensors.gps_can_magnetic_variation_degrees = proto_sensors.gps_can().gprmc().magnetic_variation();
-            sensors.gps_can_true_heading_degrees = proto_sensors.gps_can().gprmc().true_heading();
 
             std::array<float, 2> gps_can_lat_lon =
                 {proto_sensors.gps_can().gprmc().latitude(), proto_sensors.gps_can().gprmc().longitude()};
@@ -252,9 +254,13 @@ void PublishSensorData() {
             if (IsGpsCanStale(gps_can_lat_lon, gps_ais_lat_lon)) {
                 sensors.gps_can_latitude_degrees = gps_can_lat_lon[0];
                 sensors.gps_can_longitude_degrees = gps_can_lat_lon[1];
+                sensors.gps_can_true_heading_degrees = proto_sensors.gps_ais().gprmc().true_heading();
+                sensors.gps_can_groundspeed_knots = proto_sensors.gps_ais().gprmc().ground_speed();
             } else {
                 sensors.gps_can_latitude_degrees = gps_ais_lat_lon[0];
                 sensors.gps_can_longitude_degrees = gps_ais_lat_lon[1];
+                sensors.gps_can_true_heading_degrees = proto_sensors.gps_can().gprmc().true_heading();
+                sensors.gps_can_groundspeed_knots = proto_sensors.gps_can().gprmc().ground_speed();
             }
 
             // Accelerometer


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
- Resolves https://github.com/UBCSailbot/tasks/issues/7
- Add checks so that if the GPS AIS and GPS CAN data differs, and the GPS CAN data has not changed for 20 minutes, then we consider the GPS CAN data stale and publish GPS AIS latitude and longitude to the GPS CAN latitude longitude ROS topic.
- Note, we **only** get latitude and longitude from the GPS AIS so the other fields will still be the stale GPS CAN fields

### Verification
- Not done
- Need to inject purposefully stale CAN data with good AIS data.
